### PR TITLE
Allow slickAdd on initially-slideless carousel

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -597,8 +597,11 @@
         _.slidesCache = _.slides;
 
         _.slider.addClass("slick-slider");
-        _.slideTrack = _.slides.wrapAll(
-            '<div class="slick-track"/>').parent();
+
+        _.slideTrack = (_.slideCount === 0) ?
+            $('<div class="slick-track"/>').appendTo(_.slider) :
+            _.slides.wrapAll('<div class="slick-track"/>').parent();
+
         _.list = _.slideTrack.wrap(
             '<div class="slick-list"/>').parent();
         _.slideTrack.css('opacity', 0);


### PR DESCRIPTION
Calling .slick() on an children-less (slideless) element does not create a slick-track. Therefore we cannot append an intended new slide via slickAdd.
