### PR TITLE
made code example match actual code

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@ $('.single-item').slick();
 				</div>
 				<pre><code>
 $('.multiple-items').slick({
-  infinite: false,
+  infinite: true,
   slidesToShow: 3,
   slidesToScroll: 3
 });


### PR DESCRIPTION
the code backing the multiple items demo has infinite: true but the demo code had it as false creating a mismatch.
