### PR TITLE
removes blue highlight on mobile swipe android

### DIFF
--- a/slick/slick.css
+++ b/slick/slick.css
@@ -1,5 +1,5 @@
 /* Slider */
-.slick-slider { position: relative; display: block; box-sizing: border-box; -moz-box-sizing: border-box; -webkit-touch-callout: none; -webkit-user-select: none; -khtml-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none; -ms-touch-action: none; touch-action: none; }
+.slick-slider { position: relative; display: block; box-sizing: border-box; -moz-box-sizing: border-box; -webkit-touch-callout: none; -webkit-user-select: none; -khtml-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none; -ms-touch-action: none; touch-action: none; -webkit-tap-highlight-color: rgba(0,0,0,0); }
 
 .slick-list { position: relative; overflow: hidden; display: block; margin: 0; padding: 0; }
 .slick-list:focus { outline: none; }

--- a/slick/slick.scss
+++ b/slick/slick.scss
@@ -13,6 +13,7 @@
     user-select: none;
     -ms-touch-action: none;
     touch-action: none;
+    -webkit-tap-highlight-color: rgba(0,0,0,0);
 }
 .slick-list {
     position: relative;


### PR DESCRIPTION
This gets rid of the outline when swiping on android phone. Found the fix here http://css-tricks.com/snippets/css/remove-gray-highlight-when-tapping-links-in-mobile-safari/ 
