### PR TITLE
Changes bower jQuery dependency >= 1.7

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,6 @@
     "index.html"
   ],
   "dependencies": {
-    "jquery": "~1.7"
+    "jquery": ">=1.7"
   }
 }


### PR DESCRIPTION
Currently, the bower-specified jQuery dependency requires jQuery in the ~1.7 version family. In projects that use a newer version of jQuery this causes bower to register a version conflict and requires a resolution entry.

The documentation specifies "requires jQuery 1.7 +" so this PR updates the bower dependencies to reflect that.
