### PR TITLE
Positioning pagination dots to it's container

### DIFF
--- a/slick/slick.css
+++ b/slick/slick.css
@@ -43,5 +43,5 @@
 .slick-dots { position: absolute; bottom: -45px; list-style: none; display: block; text-align: center; padding: 0px; width: 100%; }
 .slick-dots li { position: relative; display: inline-block; height: 20px; width: 20px; margin: 0px 5px; padding: 0px; }
 .slick-dots li a { display: block; height: 20px; width: 20px; outline: none; line-height: 0; font-size: 0; color: transparent; padding: 5px; }
-.slick-dots li a:before { content: '\8226'; font-family: "slick"; font-size: 6px; line-height: 2; color: black; opacity: 0.25; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+.slick-dots li a:before { position: absolute; top: 0; left: 0; content: '\8226'; width: 20px; height: 20px; font-family: "slick"; font-size: 6px; line-height: 20px; text-align: center; color: black; opacity: 0.25; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
 .slick-dots li.slick-active a:before { opacity: 0.75; }

--- a/slick/slick.scss
+++ b/slick/slick.scss
@@ -189,15 +189,22 @@
             padding: 5px;
 
             &:before {
+                position: absolute;
+                top: 0;
+                left: 0;
                 content:'\8226';
+                width: 20px;
+                height: 20px;
                 font-family:"slick";
                 font-size: 6px;
-                line-height: 2;
+                line-height: 20px;
+                text-align: center;
                 color: black;
                 opacity: 0.25;
                 -webkit-font-smoothing: antialiased;
                 -moz-osx-font-smoothing: grayscale;
             }
+
         }
 
         &.slick-active a:before {


### PR DESCRIPTION
When the number of slider pages goes beyond 9, the extra character in the added digit messes up the spacing. Setting the positioning of the dot absolutely to the container for safer alignment.
