### PR TITLE
Make key-navigation work outside the slick-slider

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -747,7 +747,7 @@
             _.$list.on('mouseleave.slick', _.autoPlay);
         }
 
-        _.$list.on('keydown.slick', _.keyHandler);
+        $(window).on('keydown.slick', _.keyHandler);
 
         $(window).on('orientationchange.slick.slick-' + _.instanceUid, function() {
             _.checkResponsive();


### PR DESCRIPTION
This adds an event-listener to the window instead of the list itself.
