### PR TITLE
Negative slickIndex fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,7 +311,9 @@ $('.js-add-slide').on('click', function(){
 
 $('.js-remove-slide').on('click', function(){
   $('.add-remove').slickRemove(slideIndex - 1);
-  slideIndex--;
+  if (slideIndex !== 0) {
+  	slideIndex--;
+  }
 });
 				</code></pre>
 				<hr/>

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -117,7 +117,9 @@ $(document).ready(function() {
 
     $('.js-remove-slide').on('click', function() {
         $('.add-remove').slickRemove(slideIndex - 1);
-        slideIndex--;
+        if (slideIndex !== 0){
+            slideIndex--;
+        } 
     });
 
     $('.filtering').slick({


### PR DESCRIPTION
I like when code is fool proof, so I made two little changes. Previously it would keep on decrementing the index after it became 0. Also, the remove button probably should toggle its "disabled" state, when the index is 0.
