### PR TITLE
Allow disabling of CSS transitions

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -67,7 +67,8 @@
                 swipe: true,
                 touchMove: true,
                 touchThreshold: 5,
-                vertical: false
+                vertical: false,
+                useCSS: true
             };
 
             _.initials = {
@@ -1101,26 +1102,28 @@
             _.$slider.removeClass('slick-vertical');
         }
 
-        if (document.body.style.WebkitTransition !== undefined ||
-            document.body.style.MozTransition !== undefined ||
-            document.body.style.msTransition !== undefined) {
-            _.cssTransitions = true;
-        }
-
-        if (document.body.style.MozTransform !== undefined) {
-            _.animType = 'MozTransform';
-            _.transformType = "-moz-transform";
-            _.transitionType = 'MozTransition';
-        }
-        if (document.body.style.webkitTransform !== undefined) {
-            _.animType = 'webkitTransform';
-            _.transformType = "-webkit-transform";
-            _.transitionType = 'webkitTransition';
-        }
-        if (document.body.style.msTransform !== undefined) {
-            _.animType = 'transform';
-            _.transformType = "transform";
-            _.transitionType = 'transition';
+        if (_.options.useCSS === true) {
+             if (document.body.style.WebkitTransition !== undefined ||
+                 document.body.style.MozTransition !== undefined ||
+                 document.body.style.msTransition !== undefined) {
+                 _.cssTransitions = true;
+             }
+     
+             if (document.body.style.MozTransform !== undefined) {
+                 _.animType = 'MozTransform';
+                 _.transformType = "-moz-transform";
+                 _.transitionType = 'MozTransition';
+             }
+             if (document.body.style.webkitTransform !== undefined) {
+                 _.animType = 'webkitTransform';
+                 _.transformType = "-webkit-transform";
+                 _.transitionType = 'webkitTransition';
+             }
+             if (document.body.style.msTransform !== undefined) {
+                 _.animType = 'transform';
+                 _.transformType = "transform";
+                 _.transitionType = 'transition';
+             }
         }
 
         _.transformsEnabled = (_.animType !== null);


### PR DESCRIPTION
I have a particular use case where I need to outright disable CSS transitions regardless of browser support. This is not currently possible with Slick because it is not exposed as a global. Given my situation, I think it may be useful to provide this as an option, defaulting to `true` where support is available ([compare to FlexSlider](http://www.woothemes.com/flexslider/#gist9481310)).
