### PR TITLE
Only create slides from slide track children

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -935,7 +935,7 @@
 
         var _ = this;
 
-        _.$slides = $(_.options.slide +
+        _.$slides = $('> '+_.options.slide +
             ':not(.slick-cloned)', _.$slideTrack).addClass(
             'slick-slide');
 


### PR DESCRIPTION
When reinitializing the carousel, only children of the slide track should be considered slides, and not children the next level down. The original initialization respects this but reinit() does not, this modification to the selector should fix that.
