### PR TITLE
Fix for infinitely large carousels in Chrome.

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1036,6 +1036,7 @@
             _.$slideTrack.children('.slick-slide').width(_.slideWidth);
         }
 
+        _.$list.css("max-width", _.slideWidth * _.options.slidesToShow);
 
         if (_.options.vertical === false) {
             _.$slideTrack.width(Math.ceil((_.slideWidth * _


### PR DESCRIPTION
In Chrome in certain circumstances, the slick-list div does not provide the expected overflow:hidden behaviour. Has been seen on both desktop and Android versions of chrome.

Instead, it grows as wide as slick-track does. Due to this, every time the widths are recalculated the list is wider, and the widths get even greater as they're taken as a fraction of the list width (we've seen millions of px).

This pull request sets the max-width on the list to the width needed, stopping this issue from happening, but not breaking any existing behaviour.
