### PR TITLE
Adding a method to return slide page count

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -56,6 +56,7 @@ slickPause() | | Pause Autoplay
 slickPlay() | | Start Autoplay
 slickGoTo() | index : int | Goes to slide by index
 slickCurrentSlide() |  |  Returns the current slide index
+slickTotalPages() |  |  Returns the total number of slide pages
 slickAdd() | element : html or DOM object, index: int, addBefore: bool | Add a slide. If an index is provided, will add at that index, or before if addBefore is set. If no index is provided, add to the end or to the beginning if addBefore is set. Accepts HTML String || Object
 slideRemove() | index: int, removeBefore: bool | Remove slide by index. If removeBefore is set true, remove slide preceding index, or the first slide if no index is specified. If removeBefore is set to false, remove the slide following index, or the last slide if no index is set.
 slickFilter() | filter : selector or function | Filters slides using jQuery .filter syntax

--- a/index.html
+++ b/index.html
@@ -605,6 +605,12 @@ $(document).ready(function(){
 							<td>Returns the current slide index</td>
 						</tr>
 						<tr>
+						<tr>
+							<td>slickTotalPages</td>
+							<td>none</td>
+							<td>Returns the total number of slide pages</td>
+						</tr>
+						<tr>
 							<td>slickGoTo</td>
 							<td>int : slide number</td>
 							<td>Navigates to a slide by index</td>

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -627,6 +627,7 @@
 
         dotLimit = _.options.infinite === true ? _.slideCount + _.options.slidesToShow - _.options.slidesToScroll : _.slideCount;
 
+
         while (breaker < dotLimit) {
             dotCount++;
             dotCounter += _.options.slidesToScroll;
@@ -678,6 +679,14 @@
         }
 
         return targetLeft;
+
+    };
+
+    Slick.prototype.getSlideCount = function() {
+
+        var _ = this;
+
+        return _.slideCount;
 
     };
 
@@ -756,7 +765,7 @@
         }
 
         if(_.options.accessibility === true) {
-            _.$list.on('keydown.slick', _.keyHandler); 
+            _.$list.on('keydown.slick', _.keyHandler);
         }
 
         $(window).on('orientationchange.slick.slick-' + _.instanceUid, function() {
@@ -1672,6 +1681,11 @@
             }
 
         });
+    };
+
+    $.fn.slickTotalPages = function() {
+        var _ = this;
+        return _.get(0).slick.getSlideCount() ? _.get(0).slick.getDotCount() + 1 : 0;
     };
 
     $.fn.slickUnfilter = function() {


### PR DESCRIPTION
Adding a .slickTotalPages() to get the total number of slide pages in the slick carousel.

This is useful (along with .slickCurrentSlide()) to create custom pagination dots or other navigation displays (e.g. "Page 1 of 6").
