### PR TITLE
Include configured Slick paths when resolving via `image-url()`/`font-url()`

### DIFF
--- a/slick/slick.scss
+++ b/slick/slick.scss
@@ -13,7 +13,7 @@ $slick-dot-character: '\2022' !default;
 
 @function slick-image-url($url) {
   @if function-exists(image-url) {
-    @return image-url($url);
+    @return image-url($slick-loader-path + $url);
   }
   @else  {  
     @return url($slick-loader-path + $url);  
@@ -22,7 +22,7 @@ $slick-dot-character: '\2022' !default;
 
 @function slick-font-url($url) {
   @if function-exists(font-url) {
-    @return imag-url($url);
+    @return font-url($slick-font-path + $url);
   }
   @else  {  
     @return url($slick-font-path + $url);  


### PR DESCRIPTION
This change includes the configured loader and font paths when using the `image-url` and `font-url` helpers.

The use case here would be when Slick assets are stored within a particular directory _underneath_ whatever base paths the helper functions will prepend. Anyone who desires the previous behavior can just set `$slick-loader-path` and `$slick-font-path` to empty strings.
