### PR TITLE
Don't depend on markup for lazy load the images

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -941,11 +941,12 @@
         var _ = this,
             imgCount, targetImage;
 
-        imgCount = $('img[data-lazy]').not('[src]').length;
+        imgCount = $('img[data-lazy]').length;
 
         if (imgCount > 0) {
-            targetImage = $($('img[data-lazy]', _.$slider).not('[src]').get(0));
+            targetImage = $('img[data-lazy]', _.$slider).first();
             targetImage.attr('src', targetImage.attr('data-lazy')).removeClass('slick-loading').load(function() {
+                targetImage.removeAttr('data-lazy');
                 _.progressiveLazyLoad();
             });
         }


### PR DESCRIPTION
I was setting Slick up for a project which needed images lazy loading. I did just like the recommended markup said: added the `data-lazy` property. Unfortunately, I spent a nice portion of time trying to figure out why it was not working. When I read the source code I could understand what was happening:

The lazy load strategy depends on user's markup. The `src` tag could not be present in the HTML, because Slick would understand it as loaded. Now, it depends solely on `data-lazy` attribute: its presence will force the load, and its absence will indicate it is already loaded.

I think this may help people in future and also it makes more sense, since it is now markup independent.
