### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "slick-carousel",
-    "main": "slick/slick.min.js",
+    "main": ["slick/slick.min.js", "css/style.css"],
     "version": "1.3.6",
     "homepage": "https://github.com/kenwheeler/slick",
     "authors": [


### PR DESCRIPTION
Missing dependency on the main tag. Bower installations are dropping the css file when you wire dependencies via gulp or grunt.
