### PR TITLE
Added the missing css file to the bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "slick-carousel",
-    "main": ["slick/slick.min.js", "css/style.css"],
+    "main": ["slick/slick.min.js", "slick/slick.css"],
     "version": "1.3.6",
     "homepage": "https://github.com/kenwheeler/slick",
     "authors": [


### PR DESCRIPTION
The required CSS file is missing out of the bower.json, so it's been added in as an array.
