### PR TITLE
Fix dot transparency in IE8

### DIFF
--- a/slick/slick.css
+++ b/slick/slick.css
@@ -41,8 +41,8 @@
 
 .slick-dots { position: absolute; bottom: -45px; list-style: none; display: block; text-align: center; padding: 0px; width: 100%; }
 .slick-dots li { position: relative; display: inline-block; height: 20px; width: 20px; margin: 0px 5px; padding: 0px; cursor: pointer; }
-.slick-dots li button { border: 0; background: transparent; display: block; height: 20px; width: 20px; outline: none; line-height: 0; font-size: 0; color: transparent; padding: 5px; cursor: pointer; outline: none; position:absolute; -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=25)"; /*IE8 Fix*/}
+.slick-dots li button { border: 0; background: transparent; display: block; height: 20px; width: 20px; outline: none; line-height: 0; font-size: 0; color: transparent; padding: 5px; cursor: pointer; outline: none; /*Start IE8 Fix*/ position:absolute; -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=25)"; /*End IE8 Fix*/}
 .slick-dots li button:focus { outline: none; }
 .slick-dots li button:before { position: absolute; top: 0; left: 0; content: "\2022"; width: 20px; height: 20px; font-family: "slick"; font-size: 6px; line-height: 20px; text-align: center; color: black; opacity: 0.25; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
-.slick-dots li.slick-active button:before { opacity: 0.75; content: " \2022"; TOP: 0px; /*IE8 Fix*/}
-.slick-dots LI.slick-active button {-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=75)";}
+.slick-dots li.slick-active button:before { opacity: 0.75; /*Start IE8 Fix*/ content: " \2022"; TOP: 0px; /*End IE8 Fix*/}
+.slick-dots LI.slick-active button {-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=75)"; } /*IE8 Fix*/


### PR DESCRIPTION
I made some changes in slick.css to support  dot transparency in IE8

This is how IE8 currently displays Dots
![image](https://cloud.githubusercontent.com/assets/2680390/3078120/24159466-e45c-11e3-9509-f83b1ef8567b.png)

Here's how it looks after the changes
![image](https://cloud.githubusercontent.com/assets/2680390/3078123/695cf97e-e45c-11e3-9685-4ab57a78f4bb.png)
These screenshots were taken with IE8 on a Win7 VM from modern.ie

Demo: https://rawgit.com/salvador-guerrero/slick/master/index.html
