### PR TITLE
Firing setPosition on doc ready for earlier result

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -777,6 +777,7 @@
         });
 
         $(window).on('load.slick.slick-' + _.instanceUid, _.setPosition);
+        $(document).on('ready.slick.slick-' + _.instanceUid, _.setPosition);
 
     };
 


### PR DESCRIPTION
For my application it was useful to know what width slick set the slides to before the window onLoad event. 

By the way, thanks for the great plugin :)
