### PR TITLE
All slides active when total is less than slides to show

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1183,6 +1183,8 @@
 
             if (index > 0 && index < (_.slideCount - _.options.slidesToShow)) {
                 _.$slides.slice(index, index + _.options.slidesToShow).addClass('slick-active');
+            } else if ( allSlides.length <= _.options.slidesToShow ) {
+                allSlides.addClass('slick-active');
             } else {
                 indexOffset = _.options.infinite === true ? _.options.slidesToShow + index : index;
                 allSlides.slice(indexOffset, indexOffset + _.options.slidesToShow).addClass('slick-active');


### PR DESCRIPTION
Currently when the number of total slides is less than the number of slides to show, no slides receive the class slick-active. This simply adds the class to all slide elements when the total number is less than or equal to the number of slidesToShow set in options.
