### PR TITLE
Options object is not properly extended when using responsive settings, callbacks are removed from the options

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -464,14 +464,14 @@
                     if (targetBreakpoint !== _.activeBreakpoint) {
                         _.activeBreakpoint =
                             targetBreakpoint;
-                        _.options = $.extend({}, _.defaults,
+                        _.options = $.extend({}, _.options,
                             _.breakpointSettings[
                                 targetBreakpoint]);
                         _.refresh();
                     }
                 } else {
                     _.activeBreakpoint = targetBreakpoint;
-                    _.options = $.extend({}, _.defaults,
+                    _.options = $.extend({}, _.options,
                         _.breakpointSettings[
                             targetBreakpoint]);
                     _.refresh();
@@ -479,7 +479,7 @@
             } else {
                 if (_.activeBreakpoint !== null) {
                     _.activeBreakpoint = null;
-                    _.options = $.extend({}, _.defaults,
+                    _.options = $.extend({}, _.options,
                         _.originalSettings);
                     _.refresh();
                 }


### PR DESCRIPTION
I found that the _.options object is not properly extended when the responsive breakpoints are checked. I also found out that it works when initialising the carousel because the _.options object is properly extended with the arguments object given to the constructor by the user, i.e. _.options = $.extend({}, _.defaults, settings);. I decided to extend the existing options object instead of reseting it to its defaults. We could also decide to keep the 'settings' object, the argument object, and use it later for various reasons (such as extending the options object).
