### PR TITLE
Prevent removing non-slick elements on destroy

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -531,7 +531,9 @@
             _.$prevArrow.remove();
             _.$nextArrow.remove();
         }
-        _.$slides.unwrap().unwrap();
+        if (_.$slides.parent().hasClass('slick-track')) {
+        	_.$slides.unwrap().unwrap();
+        }
         _.$slides.removeClass(
             'slick-slide slick-active slick-visible').removeAttr('style');
         _.$slider.removeClass('slick-slider');


### PR DESCRIPTION
Slick does not check if the elements it tries to unwrap are its own. This can cause removing original elements that should never be removed.
