### PR TITLE
Add the slideCount vs. slidesToShow check in the changeSlide() function

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -496,13 +496,17 @@
         switch (event.data.message) {
 
             case 'previous':
-                _.slideHandler(_.currentSlide - _.options
+                if (_.slideCount > _.options.slidesToShow) {
+                  _.slideHandler(_.currentSlide - _.options
                     .slidesToScroll);
+                }
                 break;
 
             case 'next':
-                _.slideHandler(_.currentSlide + _.options
+                if (_.slideCount > _.options.slidesToShow) {
+                  _.slideHandler(_.currentSlide + _.options
                     .slidesToScroll);
+                }
                 break;
 
             case 'index':


### PR DESCRIPTION
Discovered this oversight in the code while assigning the left and right arrow keys to trigger slidePrev() and slideNext().
