### PR TITLE
record dragging state on Slick object instead of css class

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -74,6 +74,7 @@
 
             _.initials = {
                 animating: false,
+                dragging: false,
                 autoPlayTimer: null,
                 currentSlide: 0,
                 currentLeft: null,
@@ -1364,7 +1365,7 @@
 
         var _ = this;
 
-        _.$list.removeClass('dragging');
+        _.dragging = false;
 
         if (_.touchObject.curX === undefined) {
             return false;
@@ -1441,7 +1442,7 @@
 
         curLeft = _.getLeft(_.currentSlide);
 
-        if (!_.$list.hasClass('dragging') || touches && touches.length !== 1) {
+        if (!_.dragging || touches && touches.length !== 1) {
             return false;
         }
 
@@ -1500,7 +1501,7 @@
         _.touchObject.startX = _.touchObject.curX = touches !== undefined ? touches.pageX : event.clientX;
         _.touchObject.startY = _.touchObject.curY = touches !== undefined ? touches.pageY : event.clientY;
 
-        _.$list.addClass('dragging');
+        _.dragging = true;
 
     };
 


### PR DESCRIPTION
Currently dragging state is recorded as a css class on `.slick-list`. The problem with this is that adding/removing this class causes huge performance problems while scrolling (on mobile devices) on slides that have a lot of DOM elements. My hunch is that it triggers reflow on all nested DOM elements.

This pull request remedies the problem by recording state on the Slick object. The only caveat is that there are some styles applied when `.slick-list` has `.dragging` class. So these are lost, but in my case performance is more important.

If you think the lost styles are critical, maybe style definitions could be added via javascript on dom elements that need them. Hopefully that would not trigger reflow.

I'm happy to update the pull request if you think it's worth while.

Kudos for the great library.
