### PR TITLE
Return implicit undefined. Fixes minification errors in #324

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1435,9 +1435,9 @@
         var _ = this;
 
         if ((_.options.swipe === false) || ('ontouchend' in document && _.options.swipe === false)) {
-           return undefined;
+           return;
         } else if ((_.options.draggable === false) || (_.options.draggable === false && !event.originalEvent.touches)) {
-           return undefined;
+           return;
         }
 
         _.touchObject.fingerCount = event.originalEvent && event.originalEvent.touches !== undefined ?


### PR DESCRIPTION
I wasn't sure what minification tool you used, so I didn't touch that part. It appears that the slick.min.js is out of date from slick.js anyway, so perhaps it should be removed from version control and left for releases and the end user to do?
