### PR TITLE
slick-active not correctly set for uneven sets if slidesToScroll=slidesToShow

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1193,7 +1193,7 @@
     Slick.prototype.setSlideClasses = function(index) {
 
         var _ = this,
-            centerOffset, allSlides, indexOffset;
+            centerOffset, allSlides, indexOffset, remainder;
 
         _.$slider.find('.slick-slide').removeClass('slick-active').removeClass('slick-center');
         allSlides = _.$slider.find('.slick-slide');
@@ -1228,8 +1228,13 @@
             } else if ( allSlides.length <= _.options.slidesToShow ) {
                 allSlides.addClass('slick-active');
             } else {
+                remainder = _.slideCount%_.options.slidesToShow;
                 indexOffset = _.options.infinite === true ? _.options.slidesToShow + index : index;
-                allSlides.slice(indexOffset, indexOffset + _.options.slidesToShow).addClass('slick-active');
+                if(_.options.slidesToShow == _.options.slidesToScroll && (_.slideCount - index) < _.options.slidesToShow) {
+                    allSlides.slice(indexOffset-(_.options.slidesToShow-remainder), indexOffset + remainder).addClass('slick-active');
+                } else {
+                    allSlides.slice(indexOffset, indexOffset + _.options.slidesToShow).addClass('slick-active');
+                }
             }
 
         }


### PR DESCRIPTION
If you have an uneven set and slidesToScroll=slidesToShow the slick-active class is not correctly set for the set of slides where the last slides are shown, e.g. on http://kenwheeler.github.io/slick/ you have this problem in the uneven demo when slides 3, 4, 5, 6 are being shown. 

Hope this is the right place to fix it, but maybe it might be related to the index.
