### PR TITLE
Updated opacity variables and documentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -116,6 +116,24 @@ $slick-prev-character | string | '\2190' | Unicode character code for the previo
 $slick-next-character | string | '\2192' | Unicode character code for the next arrow icon
 $slick-dot-character | string | '\2022' | Unicode character code for the navigation dot icon
 $slick-dot-size | pixels | 6px | Size of the navigation dots
+$slick-opacity-default | value | .75 | default opacity for slick dots and arrows
+$slick-opacity-on-hover | value | 1 | opacity on hover for slick dots and arrows
+$slick-opacity-not-active | value | .25 | opacity for disabled arrows and not-active dots
+
+#### Different Icons
+
+If you want to use different icons for the arrows or dots you can easily achieve this by setting the according Slick Sass variables to different values. For example install `FontAwesome` as described [here](http://fontawesome.io/get-started/). 
+
+Then set:
+
+    $slick-font-family: 'FontAwesome';
+    $slick-prev-character: '\f0a8';
+    $slick-next-character: '\f0a9';
+    $slick-dot-character: '\f111';
+
+If you have installed `FontAwesome` locally, you need to also adjust the `$slick-font-path`.
+
+Of course, you can use any other icon font that you like.
 
 
 #### Dependencies

--- a/slick/slick.css
+++ b/slick/slick.css
@@ -3,7 +3,7 @@
 
 .slick-list { position: relative; overflow: hidden; display: block; margin: 0; padding: 0; }
 .slick-list:focus { outline: none; }
-.slick-loading .slick-list { background: white url('ajax-loader.gif') center center no-repeat; }
+.slick-loading .slick-list { background: white url("./ajax-loader.gif") center center no-repeat; }
 .slick-list.dragging { cursor: pointer; cursor: hand; }
 
 .slick-slider .slick-list, .slick-track, .slick-slide, .slick-slide img { -webkit-transform: translate3d(0, 0, 0); -moz-transform: translate3d(0, 0, 0); -ms-transform: translate3d(0, 0, 0); -o-transform: translate3d(0, 0, 0); transform: translate3d(0, 0, 0); }
@@ -22,14 +22,14 @@
 .slick-vertical .slick-slide { display: block; height: auto; border: 1px solid transparent; }
 
 /* Icons */
-@font-face { font-family: "slick"; src: url('fonts/slick.eot'); src: url('fonts/slick.eot?#iefix') format("embedded-opentype"), url('fonts/slick.woff') format("woff"), url('fonts/slick.ttf') format("truetype"), url('fonts/slick.svg#slick') format("svg"); font-weight: normal; font-style: normal; }
-
+@font-face { font-family: "slick"; src: url("./fonts/slick.eot"); src: url("./fonts/slick.eot?#iefix") format("embedded-opentype"), url("./fonts/slick.woff") format("woff"), url("./fonts/slick.ttf") format("truetype"), url("./fonts/slick.svg#slick") format("svg"); font-weight: normal; font-style: normal; }
 /* Arrows */
 .slick-prev, .slick-next { position: absolute; display: block; height: 20px; width: 20px; line-height: 0; font-size: 0; cursor: pointer; background: transparent; color: transparent; top: 50%; margin-top: -10px; padding: 0; border: none; outline: none; }
-.slick-prev:focus, .slick-next:focus { outline: none; }
+.slick-prev:hover, .slick-prev:focus, .slick-next:hover, .slick-next:focus { outline: none; background: transparent; color: transparent; }
+.slick-prev:hover:before, .slick-prev:focus:before, .slick-next:hover:before, .slick-next:focus:before { opacity: 1; }
 .slick-prev.slick-disabled:before, .slick-next.slick-disabled:before { opacity: 0.25; }
 
-.slick-prev:before, .slick-next:before { font-family: "slick"; font-size: 20px; line-height: 1; color: white; opacity: 0.85; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+.slick-prev:before, .slick-next:before { font-family: "slick"; font-size: 20px; line-height: 1; color: white; opacity: 0.75; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
 
 .slick-prev { left: -25px; }
 .slick-prev:before { content: "\2190"; }
@@ -40,9 +40,10 @@
 /* Dots */
 .slick-slider { margin-bottom: 30px; }
 
-.slick-dots { position: absolute; bottom: -45px; list-style: none; display: block; text-align: center; padding: 0px; width: 100%; }
-.slick-dots li { position: relative; display: inline-block; height: 20px; width: 20px; margin: 0px 5px; padding: 0px; cursor: pointer; }
+.slick-dots { position: absolute; bottom: -45px; list-style: none; display: block; text-align: center; padding: 0; width: 100%; }
+.slick-dots li { position: relative; display: inline-block; height: 20px; width: 20px; margin: 0 5px; padding: 0; cursor: pointer; }
 .slick-dots li button { border: 0; background: transparent; display: block; height: 20px; width: 20px; outline: none; line-height: 0; font-size: 0; color: transparent; padding: 5px; cursor: pointer; }
-.slick-dots li button:focus { outline: none; }
+.slick-dots li button:hover, .slick-dots li button:focus { outline: none; }
+.slick-dots li button:hover:before, .slick-dots li button:focus:before { opacity: 1; }
 .slick-dots li button:before { position: absolute; top: 0; left: 0; content: "\2022"; width: 20px; height: 20px; font-family: "slick"; font-size: 6px; line-height: 20px; text-align: center; color: black; opacity: 0.25; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
-.slick-dots li.slick-active button:before { opacity: 0.75; }
+.slick-dots li.slick-active button:before { color: black; opacity: 0.75; }

--- a/slick/slick.scss
+++ b/slick/slick.scss
@@ -12,9 +12,9 @@ $slick-prev-character: '\2190' !default;
 $slick-next-character: '\2192' !default;
 $slick-dot-character: '\2022' !default;
 $slick-dot-size: 6px !default;
-$opacity-default: .75;
-$opacity-on-hover: 1;
-$opacity-not-active: .25;
+$slick-opacity-default: .75 !default;
+$slick-opacity-on-hover: 1 !default;
+$slick-opacity-not-active: .25 !default;
 
 
 @function slick-image-url($url) {
@@ -172,11 +172,11 @@ $opacity-not-active: .25;
       background: transparent;
       color: transparent;
       &:before {
-        opacity: $opacity-on-hover;
+        opacity: $slick-opacity-on-hover;
       }
     }
     &.slick-disabled:before {
-        opacity: $opacity-not-active;
+        opacity: $slick-opacity-not-active;
     }
 }
 .slick-prev:before, .slick-next:before {
@@ -184,7 +184,7 @@ $opacity-not-active: .25;
     font-size: 20px;
     line-height: 1;
     color: $slick-arrow-color;
-    opacity: $opacity-default;
+    opacity: $slick-opacity-default;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 }
@@ -239,7 +239,7 @@ $opacity-not-active: .25;
             &:hover, &:focus {
                 outline: none;
                 &:before {
-                  opacity: $opacity-on-hover;
+                  opacity: $slick-opacity-on-hover;
                 }
             }
 
@@ -255,7 +255,7 @@ $opacity-not-active: .25;
                 line-height: 20px;
                 text-align: center;
                 color: $slick-dot-color;
-                opacity: $opacity-not-active;
+                opacity: $slick-opacity-not-active;
                 -webkit-font-smoothing: antialiased;
                 -moz-osx-font-smoothing: grayscale;
             }
@@ -264,7 +264,7 @@ $opacity-not-active: .25;
 
         &.slick-active button:before {
             color: $slick-dot-color-active;
-            opacity: $opacity-default;
+            opacity: $slick-opacity-default;
         }
     }
 }


### PR DESCRIPTION
1. `slick`ified opacity Sass variables
2. documented opacity Sass variables in README.markdown
3. documented how-to choose different icons in README.markdown
4. `sass slick.scss slick.css --style compact`
