### PR TITLE
fix image-url call, only has one parameter, not 3

### DIFF
--- a/slick/slick.scss
+++ b/slick/slick.scss
@@ -19,7 +19,7 @@ $opacity-not-active: .25;
 
 @function slick-image-url($url) {
   @if function-exists(image-url) {
-    @return image-url($url, false, false);
+    @return image-url($url);
   }
   @else  {
     @return url($slick-loader-path + $url);


### PR DESCRIPTION
sass-rails image-url helper has only one parameter, not 3. 