### PR TITLE
Added a method for getting the (un)paused status of a slick carousel.

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1711,6 +1711,11 @@
         });
     };
 
+    $.fn.slickIsPaused = function() {
+        var _ = this;
+        return _.get(0).slick.paused;
+    };
+
     $.fn.slickNext = function() {
         var _ = this;
         return _.each(function(index, element) {


### PR DESCRIPTION
I'm using Slick with a custom control panel with a play/pause button and need to know whether or not the Slick instance was paused.