### PR TITLE
BUG-FIX: Image dragging off browser to machine

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -33,7 +33,7 @@
 .more,.button.first{margin-top:40px;}
 .red{background:#e74c3c;color:#fff;}
 .slick-slide .image{padding:10px;}
-.slick-slide img{border:5px solid #FFF;display:block;width:100%;}
+.slick-slide img{border:5px solid #FFF;display:block;width:100%;-moz-user-select:none;-webkit-user-select:none;-webkit-user-drag:none;}
 .slick-slide img.slick-loading{border:0 }
 .slick-slider{margin:30px auto 50px;}
 .subheading{color:#555;font-size:12px;font-style:italic;font-weight:400;margin:10px auto;text-align:center;}


### PR DESCRIPTION
Disable the ability to drag an image in the slide to copy it somewhere on machine. This caused issues on Safari mainly. There was an image background, copy, and buttons overlay the image. Every time the slide was clicked to drag, it would give a transparency to copy the image to my machine ( Mac OS X 10.9.3 ). This fix disables that feature by adding 3 CSS rules. Which I believe the default behavior you have is unexpected and could cause issues on any number of devices. See attached screenshots for a clearer picture.
(Chrome)
![screenshot 2014-07-09 10 55 23](https://cloud.githubusercontent.com/assets/4925333/3526314/d083e5f4-077a-11e4-9759-0f2eadc0008d.png)
(Safari - while dragging)
![screenshot 2014-07-09 11 14 22 2](https://cloud.githubusercontent.com/assets/4925333/3526431/d9b97b60-077b-11e4-84e5-29fbb9b26048.png)

*After you are done dragging, it adds it to your desktop