### PR TITLE
Update slick.js

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -43,15 +43,15 @@
                 appendArrows: $(element),
                 arrows: true,
                 asNavFor: null,
-                prevArrow: '<button type="button" class="slick-prev">Previous</button>',
-                nextArrow: '<button type="button" class="slick-next">Next</button>',
+                prevArrow: '<button type="button" data-role="none" class="slick-prev">Previous</button>',
+                nextArrow: '<button type="button" data-role="none" class="slick-next">Next</button>',
                 autoplay: false,
                 autoplaySpeed: 3000,
                 centerMode: false,
                 centerPadding: '50px',
                 cssEase: 'ease',
                 customPaging: function(slider, i) {
-                    return '<button type="button">' + (i + 1) + '</button>';
+                    return '<button type="button" data-role="none">' + (i + 1) + '</button>';
                 },
                 dots: false,
                 draggable: true,


### PR DESCRIPTION
jQuery Mobile was adding ui-btn classes to next and previous buttons destroying carousel layout.
