### PR TITLE
fixed 404 error for ajax-loader.gif

### DIFF
--- a/slick/slick.scss
+++ b/slick/slick.scss
@@ -64,7 +64,8 @@ $opacity-not-active: .25;
     }
 
     .slick-loading & {
-        background: #fff slick-image-url("ajax-loader.gif") center center no-repeat;
+        $path: $slick-loader-path + "ajax-loader.gif";
+        background: #fff slick-image-url($path) center center no-repeat;
     }
 
     &.dragging {


### PR DESCRIPTION
I was always getting a 404 error for the ajax-loader.gif image.  This fixed the problem.