### PR TITLE
Remove missing function calls

### DIFF
--- a/slick/slick.scss
+++ b/slick/slick.scss
@@ -19,18 +19,12 @@ $opacity-not-active: .25;
 
 @function slick-image-url($url) {
   @if function-exists(image-url) {
-    @return image-url($url, false, false);
-  }
-  @else  {
     @return url($slick-loader-path + $url);
   }
 }
 
 @function slick-font-url($url) {
   @if function-exists(font-url) {
-    @return font-url($url);
-  }
-  @else  {
     @return url($slick-font-path + $url);
   }
 }


### PR DESCRIPTION
This might just be my issue, but I'm using libsass to compile and I'm not getting any working paths for the loader or fonts. The only way I could fix them was by removing the "compass" specific functions that were missing. I expected it to fallback but it never did.