### PR TITLE
Use .detach() instead of .remove()

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -196,7 +196,7 @@
 
         _.$slides = _.$slideTrack.children(this.options.slide);
 
-        _.$slideTrack.children(this.options.slide).remove();
+        _.$slideTrack.children(this.options.slide).detach();
 
         _.$slideTrack.append(_.$slides);
         
@@ -643,7 +643,7 @@
 
             _.unload();
 
-            _.$slideTrack.children(this.options.slide).remove();
+            _.$slideTrack.children(this.options.slide).detach();
 
             _.$slidesCache.filter(filter).appendTo(_.$slideTrack);
 
@@ -1060,7 +1060,7 @@
 
         _.$slides = _.$slideTrack.children(this.options.slide);
 
-        _.$slideTrack.children(this.options.slide).remove();
+        _.$slideTrack.children(this.options.slide).detach();
 
         _.$slideTrack.append(_.$slides);
 
@@ -1613,7 +1613,7 @@
 
             _.unload();
 
-            _.$slideTrack.children(this.options.slide).remove();
+            _.$slideTrack.children(this.options.slide).detach();
 
             _.$slidesCache.appendTo(_.$slideTrack);
 


### PR DESCRIPTION
For addSlide, filterSlides, removeSlide, unfilterSlides, using .detach() will keep jQuery data and events wired up to the slides. jQuery actually recommends using .detach() for exactly what you're using it for instead of .remove().

I have this monkey-patched for my current Backbone project.
