### PR TITLE
Fixed initial slide width calculation in centerMode

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1099,19 +1099,14 @@
 
         var _ = this;
 
-
         if (_.options.vertical === false) {
-            _.$slideTrack.width(Math.ceil((_.slideWidth * _
-                .$slideTrack.children('.slick-slide').length)));
             if (_.options.centerMode === true) {
                 _.$list.css({
                     padding: ('0px ' + _.options.centerPadding)
                 });
             }
         } else {
-            _.$list.height(_.$slides.first().outerHeight() * _.options.slidesToShow);
-            _.$slideTrack.height(Math.ceil((_.$slides.first().outerHeight() * _
-                .$slideTrack.children('.slick-slide').length)));
+            _.$list.height(_.$slides.first().outerHeight(true) * _.options.slidesToShow);
             if (_.options.centerMode === true) {
                 _.$list.css({
                     padding: (_.options.centerPadding + ' 0px')
@@ -1121,18 +1116,20 @@
 
         _.listWidth = _.$list.width();
         _.listHeight = _.$list.height();
+
+
         if(_.options.vertical === false) {
-        _.slideWidth = Math.ceil(_.listWidth / _.options
-            .slidesToShow);
+            _.slideWidth = Math.ceil(_.listWidth / _.options.slidesToShow);
+            _.$slideTrack.width(Math.ceil((_.slideWidth * _.$slideTrack.children('.slick-slide').length)));
+        
         } else {
-        _.slideWidth = Math.ceil(_.listWidth);
+            _.slideWidth = Math.ceil(_.listWidth);
+            _.$slideTrack.height(Math.ceil((_.$slides.first().outerHeight(true) * _.$slideTrack.children('.slick-slide').length)));
+        
         }
 
-        if (_.options.centerMode === true) {
-            _.$slideTrack.children('.slick-slide').width(_.slideWidth);
-        } else {
-            _.$slideTrack.children('.slick-slide').width(_.slideWidth);
-        }
+        var offset = _.$slides.first().outerWidth(true) - _.$slides.first().width();
+        _.$slideTrack.children('.slick-slide').width(_.slideWidth - offset);
 
     };
 


### PR DESCRIPTION
Here is an example:
http://jsfiddle.net/bj566/6/

Initial slide width is calculated without the left and right padding set by 'centerPadding'.
The width is changed (and calculated correctly) after the slides are moved or the page is resized.

Element dimensions should be calculated in different order.

First set the padding set in 'centerPadding' to the list.
Then get the list size and and calculate slide width. 
