### PR TITLE
Settings using data attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,6 +113,33 @@ $('.multiple-items').slick({
   slidesToScroll: 3
 });
 				</code></pre>
+				<h2>Data attributes</h2>
+				<div class="slider data-attributes" data-slick='{ "dots": true, "infinite": true, "speed": 300, "slidesToShow": 3, "slidesToScroll": 3}'>
+					<div><h3>1</h3></div>
+					<div><h3>2</h3></div>
+					<div><h3>3</h3></div>
+					<div><h3>4</h3></div>
+					<div><h3>5</h3></div>
+					<div><h3>6</h3></div>
+					<div><h3>7</h3></div>
+					<div><h3>8</h3></div>
+					<div><h3>9</h3></div>
+				</div>
+				<pre><code>
+&lt;div class="slider data-attributes" data-slick='{ "dots": true, "infinite": true, "speed": 300, "slidesToShow": 3, "slidesToScroll": 3}'&gt;
+	&lt;div&gt;&lt;h3&gt;1&lt;/h3&gt;&lt;/div&gt;
+	&lt;div&gt;&lt;h3&gt;2&lt;/h3&gt;&lt;/div&gt;
+	&lt;div&gt;&lt;h3&gt;3&lt;/h3&gt;&lt;/div&gt;
+	&lt;div&gt;&lt;h3&gt;4&lt;/h3&gt;&lt;/div&gt;
+	&lt;div&gt;&lt;h3&gt;5&lt;/h3&gt;&lt;/div&gt;
+	&lt;div&gt;&lt;h3&gt;6&lt;/h3&gt;&lt;/div&gt;
+	&lt;div&gt;&lt;h3&gt;7&lt;/h3&gt;&lt;/div&gt;
+	&lt;div&gt;&lt;h3&gt;8&lt;/h3&gt;&lt;/div&gt;
+	&lt;div&gt;&lt;h3&gt;9&lt;/h3&gt;&lt;/div&gt;
+&lt;/div&gt;
+
+$('.data-attributes').slick();
+                </code></pre>
 				<hr/>
 				<h2>Responsive Display</h2>
 				<div class="slider responsive">

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -13,6 +13,7 @@ $(document).ready(function() {
         slidesToShow: 3,
         slidesToScroll: 3
     });
+    $('.data-attributes').slick();
     $('.one-time').slick({
         dots: true,
         infinite: false,

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -35,12 +35,12 @@
 
         function Slick(element, settings) {
 
-            var _ = this,
+            var _ = this, $element = $(element),
                 responsiveSettings, breakpoint;
 
             _.defaults = {
                 accessibility: true,
-                appendArrows: $(element),
+                appendArrows: $element,
                 arrows: true,
                 asNavFor: null,
                 prevArrow: '<button type="button" class="slick-prev">Previous</button>',
@@ -114,14 +114,14 @@
             _.cssTransitions = false;
             _.paused = false;
             _.positionProp = null;
-            _.$slider = $(element);
+            _.$slider = $element;
             _.$slidesCache = null;
             _.transformType = null;
             _.transitionType = null;
             _.windowWidth = 0;
-            _.windowTimer = null;
-
-            _.options = $.extend({}, _.defaults, settings);
+            _.windowTimer = null;            
+                       
+            _.options = $.extend({}, _.defaults, $element.data('slick') || {}, settings);
 
             _.originalSettings = _.options;
             responsiveSettings = _.options.responsive || null;


### PR DESCRIPTION
Configuring slick using an attribute on the element, instead of calling it settings as mentioned in issue https://github.com/kenwheeler/slick/issues/91 I called it slick to avoid potential collisions. For the sake of documentation I've also added a little demo to index.html.
