### PR TITLE
Deep clone to copy any events attached to slides

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1286,12 +1286,12 @@
                 for (i = _.slideCount; i > (_.slideCount -
                     infiniteCount); i -= 1) {
                     slideIndex = i - 1;
-                    $(_.$slides[slideIndex]).clone().attr('id', '').prependTo(
+                    $(_.$slides[slideIndex]).clone(true).attr('id', '').prependTo(
                         _.$slideTrack).addClass('slick-cloned');
                 }
                 for (i = 0; i < infiniteCount; i += 1) {
                     slideIndex = i;
-                    $(_.$slides[slideIndex]).clone().attr('id', '').appendTo(
+                    $(_.$slides[slideIndex]).clone(true).attr('id', '').appendTo(
                         _.$slideTrack).addClass('slick-cloned');
                 }
                 _.$slideTrack.find('.slick-cloned').find('[id]').each(function() {


### PR DESCRIPTION
Came across this issue when using slick combined with knockout bindings.  The click bindings on the slides worked fine, however the clones didn't retain their events.  This solved the issue.
