### PR TITLE
Fix index check when slick isn't in centered mode

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1245,7 +1245,7 @@
 
         } else {
 
-            if (index > 0 && index < (_.slideCount - _.options.slidesToShow)) {
+            if (index >= 0 && index <= (_.slideCount - _.options.slidesToShow)) {
                 _.$slides.slice(index, index + _.options.slidesToShow).addClass('slick-active');
             } else if ( allSlides.length <= _.options.slidesToShow ) {
                 allSlides.addClass('slick-active');


### PR DESCRIPTION
The first and last elements weren't in the conditional/loop to receive the 'slick-active' class.
