### PR TITLE
Add waitForAnimate option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -70,6 +70,7 @@ touchThreshold | int | 5 | To advance slides, the user must swipe a length of (1
 useCSS | boolean | true | Enable/Disable CSS Transitions
 vertical | boolean | false | Vertical slide direction
 rtl | boolean | false | Change the slider's direction to become right-to-left
+waitForAnimate | boolean | true | Ignores requests to advance the slide while animating
 
 
 #### Methods

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -77,7 +77,8 @@
                 touchMove: true,
                 touchThreshold: 5,
                 useCSS: true,
-                vertical: false
+                vertical: false,
+                waitForAnimate: true
             };
 
             _.initials = {
@@ -1139,11 +1140,11 @@
         if(_.options.vertical === false) {
             _.slideWidth = Math.ceil(_.listWidth / _.options.slidesToShow);
             _.$slideTrack.width(Math.ceil((_.slideWidth * _.$slideTrack.children('.slick-slide').length)));
-        
+
         } else {
             _.slideWidth = Math.ceil(_.listWidth);
             _.$slideTrack.height(Math.ceil((_.$slides.first().outerHeight(true) * _.$slideTrack.children('.slick-slide').length)));
-        
+
         }
 
         var offset = _.$slides.first().outerWidth(true) - _.$slides.first().width();
@@ -1365,7 +1366,7 @@
         var targetSlide, animSlide, slideLeft, unevenOffset, targetLeft = null,
             _ = this;
 
-        if (_.animating === true) {
+        if (_.animating === true && _.options.waitForAnimate === true) {
             return false;
         }
 


### PR DESCRIPTION
Default behaviour of slide transitions is to ignore all requests to advance the slide while animating. This option allows that default behaviour to be changed.

This option is especially desirable when using the javascript method slickGoTo(index) because the default behaviour causes calls to slickGoTo(index) to be dropped if it is in the middle of an animation.
