### PR TITLE
fixed range calculation for lazyLoad

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -906,12 +906,21 @@
             });
         }
 
-        if (_.options.centerMode === true || _.options.fade === true ) {
-            rangeStart = _.options.slidesToShow + _.currentSlide - 1;
-            rangeEnd = rangeStart + _.options.slidesToShow + 2;
+        if (_.options.centerMode === true) {
+            if (_.options.infinite === true) {
+                rangeStart = _.currentSlide + (_.options.slidesToShow/2 + 1);
+                rangeEnd = rangeStart + _.options.slidesToShow + 2;
+            } else {
+                rangeStart = Math.max(0, _.currentSlide - (_.options.slidesToShow/2 + 1));
+                rangeEnd = 2 + (_.options.slidesToShow/2 + 1) + _.currentSlide;
+            }
         } else {
             rangeStart = _.options.infinite ? _.options.slidesToShow + _.currentSlide : _.currentSlide;
             rangeEnd = rangeStart + _.options.slidesToShow;
+            if (_.options.fade === true ) {
+                if(rangeStart > 0) rangeStart--;
+                if(rangeEnd <= _.slideCount) rangeEnd++;
+            }
         }
 
         loadRange = _.$slider.find('.slick-slide').slice(rangeStart, rangeEnd);


### PR DESCRIPTION
center mode requires different range calculation as slidesToShow/2 slides are displayed before and after the current slide.

this should fix issue kenwheeler/slick#358 and also implements a fixed range-calculation for the "fade" option that preloads the previous and next image (as previously resolved in issue kenwheeler/slick#186 / pull-request kenwheeler/slick#219 by simply making it behave like the "center" option)
