### PR TITLE
Add perspective feature detection for prefixes

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1204,7 +1204,7 @@
             _.animType = 'OTransform';
             _.transformType = "-o-transform";
             _.transitionType = 'OTransition';
-            if (bodyStyle.perspectiveProperty === undefined && bodyStyle.WebkitPerspective === undefined) _.animType = false;
+            if (bodyStyle.perspectiveProperty === undefined && bodyStyle.webkitPerspective === undefined) _.animType = false;
         }
         if (bodyStyle.MozTransform !== undefined) {
             _.animType = 'MozTransform';
@@ -1222,7 +1222,7 @@
             _.animType = 'msTransform';
             _.transformType = "-ms-transform";
             _.transitionType = 'msTransition';
-            if (bodyStyle.perspectiveProperty === undefined && bodyStyle.msPerspective === undefined) _.animType = false;
+            if (bodyStyle.msTransform === undefined) _.animType = false;
         }
         if (bodyStyle.transform !== undefined && _.animType !== false) {
             _.animType = 'transform';


### PR DESCRIPTION
Currently Opera 12.16 and possibly some versions around it break from the prefixing. This update checks for the perspective property for the different vendors as a second check to ensure the browsers will display correctly. If not it defaults to false which would then not use the CSS styling effects.

Also threw document.body.style in a variable for a little caching.
