### PR TITLE
add user defineable option to set slideWidth to an absolute value

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -72,6 +72,7 @@
                 slide: 'div',
                 slidesToShow: 1,
                 slidesToScroll: 1,
+                slideWidth: null,
                 speed: 300,
                 swipe: true,
                 touchMove: true,
@@ -1138,7 +1139,11 @@
 
 
         if(_.options.vertical === false) {
-            _.slideWidth = Math.ceil(_.listWidth / _.options.slidesToShow);
+            if (_.options.slideWidth === null) {
+                _.slideWidth = Math.ceil(_.listWidth / _.options.slidesToShow)
+            } else {
+                _.slideWidth = _.options.slideWidth;
+            }
             _.$slideTrack.width(Math.ceil((_.slideWidth * _.$slideTrack.children('.slick-slide').length)));
 
         } else {


### PR DESCRIPTION
I found the need for a static, absolute width for all slides for greater control in my implementation's design layout. As such, I didn't want the width of the slides calculated dynamically based on the container size, but explicitly defined by me in the options. So I added a `slideWidth` option to `_.options` which is used instead if it is not `null`.