### PR TITLE
Unset width on destroy & unload, instead of removing style attribute

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -581,7 +581,7 @@
             _.$slides.unwrap().unwrap();
         }
         _.$slides.removeClass(
-            'slick-slide slick-active slick-visible').removeAttr('style');
+            'slick-slide slick-active slick-visible').css('width', '');
         _.$slider.removeClass('slick-slider');
         _.$slider.removeClass('slick-initialized');
 
@@ -1665,7 +1665,7 @@
             _.$nextArrow.remove();
         }
         _.$slides.removeClass(
-            'slick-slide slick-active slick-visible').removeAttr('style');
+            'slick-slide slick-active slick-visible').css('width', '');
 
     };
 


### PR DESCRIPTION
Fixes #252 with a more conservative approach to unsetting width on destroy and unload.

Removes the inline width by setting it to an empty string, instead of removing all inline styles.

Uses an empty string instead of auto, because an inline auto still overrides widths set elsewhere that should take effect on destroy or unload—for example, a carousel on small screens that becomes a grid on larger screens.
