### PR TITLE
Improve Selector Search for asNavFor and focusOnSelect

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -551,7 +551,7 @@
                 break;
 
             case 'index':
-                var index = $(event.target).parent().index() * _.options.slidesToScroll;
+                var index = $(event.target).parents('.slick-slide').first().index() * _.options.slidesToScroll;
                 _.slideHandler(index);
                 if(asNavFor != null)  asNavFor.slideHandler(index);                break;
 
@@ -1345,7 +1345,7 @@
 
         var _ = this;
         var asNavFor = _.options.asNavFor != null ? $(_.options.asNavFor).getSlick() : null;
-        var index = parseInt($(event.target).parent().attr("index"));
+        var index = parseInt($(event.target).parents('.slick-slide').first().attr("index"));
         if(!index) index = 0;
 
         if(_.slideCount <= _.options.slidesToShow){


### PR DESCRIPTION
Clicking on slides for a slick instance with `asNavFor: true` causes the index lookup to resolve to `undefined` when the `.slick-slide` contains child elements.

This fix continues up through the parents of `event.target` until it finds the DOM node with the `slick-slide` class instead of requiring it be the immediate parent of `event.target`.
