### PR TITLE
Progressive Lazy Load option fix for 404 requests

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -995,7 +995,11 @@
             targetImage.attr('src', targetImage.attr('data-lazy')).removeClass('slick-loading').load(function() {
                 targetImage.removeAttr('data-lazy');
                 _.progressiveLazyLoad();
-            });
+            })
+	       .error(function () {
+	       	targetImage.removeAttr('data-lazy');
+	       	_.progressiveLazyLoad();
+	       });
         }
 
     };


### PR DESCRIPTION
Currently if a image 404's or has any other error then the .load callback is never called, which means the recursive function stops right there. This proposed change is to handle any image error and continue loading additional images.
