### PR TITLE
Fixing focusOnSelect mode when using nested DOM for slider thumbnails.

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1347,7 +1347,7 @@
 
         var _ = this;
         var asNavFor = _.options.asNavFor != null ? $(_.options.asNavFor).getSlick() : null;
-        var index = parseInt($(event.target).parent().attr("index"));
+        var index = parseInt($(event.target).closest('.slick-slide').attr("index"));
         if(!index) index = 0;
 
         if(_.slideCount <= _.options.slidesToShow){


### PR DESCRIPTION
This PR solves an issue with the asNavFor option in conjunciton with the selectOnFocus option when using nested DOM for the thumbnails.
