### PR TITLE
Stop dots from maintaining focus after being clicked

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1704,6 +1704,7 @@
 
         if (_.$dots !== null) {
 
+            _.$dots.find('li.slick-active').children().blur();
             _.$dots.find('li').removeClass('slick-active');
             _.$dots.find('li').eq(Math.floor(_.currentSlide / _.options.slidesToScroll)).addClass('slick-active');
 


### PR DESCRIPTION
When autoplay=true dots (that is, the button element) would maintain focus and appear to be active once clicked, even though the slide had changed.
