### PR TITLE
Fix for progressive lazy-loading in IE8

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1000,6 +1000,7 @@
 
         if (imgCount > 0) {
             targetImage = $('img[data-lazy]', _.$slider).first();
+            targetImage.attr('src', null);
             targetImage.attr('src', targetImage.attr('data-lazy')).removeClass('slick-loading').load(function() {
                 targetImage.removeAttr('data-lazy');
                 _.progressiveLazyLoad();


### PR DESCRIPTION
IE8 doesn't load images when lazy load is set to progressive. With this hack it forces IE to load the image when the src is changed.