### PR TITLE
Add tree new api methods

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -88,6 +88,9 @@ slickPause() | | Pause Autoplay
 slickPlay() | | Start Autoplay
 slickGoTo() | index : int | Goes to slide by index
 slickCurrentSlide() |  |  Returns the current slide index
+slickNumberOfSlides() |  |  Return the number os slides
+slickFirstSlide() |  |  Return the first slide DOM element
+slickLastSlide() |  |  Return the last slide DOM element
 slickAdd() | element : html or DOM object, index: int, addBefore: bool | Add a slide. If an index is provided, will add at that index, or before if addBefore is set. If no index is provided, add to the end or to the beginning if addBefore is set. Accepts HTML String || Object
 slideRemove() | index: int, removeBefore: bool | Remove slide by index. If removeBefore is set true, remove slide preceding index, or the first slide if no index is specified. If removeBefore is set to false, remove the slide following index, or the last slide if no index is set.
 slickFilter() | filter : selector or function | Filters slides using jQuery .filter syntax

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -681,6 +681,33 @@
 
     };
 
+    Slick.prototype.getFirstSlide = function() {
+
+        var _ = this;
+        var $slides = _.$slides;
+
+        return $slides[0];
+
+   };
+
+   Slick.prototype.getLastSlide = function() {
+
+        var _ = this;
+        var $slides = _.$slides;
+
+        return $slides[$slides.length - 1];
+
+   };
+
+   Slick.prototype.getNumberOfSlides = function() {
+
+        var _ = this;
+        var $slides = _.$slides;
+
+        return $slides.length;
+
+   };
+
     Slick.prototype.getDotCount = function() {
 
         var _ = this,
@@ -1780,6 +1807,21 @@
     $.fn.slickCurrentSlide = function() {
         var _ = this;
         return _.get(0).slick.getCurrent();
+    };
+
+    $.fn.slickFirstSlide = function() {
+        var _ = this;
+        return _.get(0).slick.getFirstSlide();
+    };
+
+    $.fn.slickLastSlide = function() {
+        var _ = this;
+        return _.get(0).slick.getLastSlide();
+    };
+
+    $.fn.slickNumberOfSlides = function() {
+        var _ = this;
+        return _.get(0).slick.getNumberOfSlides();
     };
 
     $.fn.slickFilter = function(filter) {


### PR DESCRIPTION
Hi, I started to use this slider this week, it's really cool, congratulations.

So, I needed some methods to put in an application to test the number of slides to disable or not the prev/next arrows. I think that is a really simple thing, but in many cases can be helpful. With these methods is very ease to set something like this:

```javascript
var numberOfSlides = $slider.slickNumberOfSlides();
var currentSlide = $slider.slickCurrentSlide() + 1;

if (currentSlide === numberOfSlides) {
    // some stuff
}
```

So, I just added some two methods to the api: `$fn.slickFirstSlide()` and `$fn.slick.LastSlick()`. That return the first and the last slide DOM element. It's is good to manipulate the elements easily.

That's it :smile_cat:

***NOTE:** the commit message is wrong, is just tree methods no four ;p*