### PR TITLE
Ignore package.json for bower installs.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
         "bower_components",
         "test",
         "tests",
+        "package.json",
         "index.html"
     ],
     "dependencies": {


### PR DESCRIPTION
If package.json is present and i attempt to use browserify to require slick from the bower_components folder the package.json seems to confuse browserify and it's no longer able to find jquery to require.

browserify throws this error when package.json is present:-
```
Command failed: Error: Cannot find module 'jquery'
```