### PR TITLE
Fix to be fully responsive on all devices

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -497,7 +497,7 @@
 
             for (breakpoint in _.breakpoints) {
                 if (_.breakpoints.hasOwnProperty(breakpoint)) {
-                    if ($(window).width() < _.breakpoints[
+                    if ($(window.innerWidth)[0] < _.breakpoints[
                         breakpoint]) {
                         targetBreakpoint = _.breakpoints[
                             breakpoint];
@@ -863,10 +863,10 @@
         });
 
         $(window).on('resize.slick.slick-' + _.instanceUid, function() {
-            if ($(window).width() !== _.windowWidth) {
+            if ($(window.innerWidth)[0] !== _.windowWidth) {
                 clearTimeout(_.windowDelay);
                 _.windowDelay = window.setTimeout(function() {
-                    _.windowWidth = $(window).width();
+                    _.windowWidth = $(window.innerWidth)[0];
                     _.checkResponsive();
                     _.setPosition();
                 }, 50);


### PR DESCRIPTION
I found that using $(window).width() created a problem as that line also counted the scrollbar width. That created some differences beetween CSS breakpoints and the plugin JS reponsive function as they had a difference of 16px (the width of the scrollbar), these can be seen in the http://kenwheeler.github.io/slick/ responsive example, if you reduce the browser to 1040px width you can check that it will trigger the 1024px breakpoint.