### PR TITLE
Ensuring all slick slides never clear floats

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -32,6 +32,7 @@
 .margin-40{margin-bottom:40px;}
 .more,.button.first{margin-top:40px;}
 .red{background:#e74c3c;color:#fff;}
+.slick-slide{clear:none !important;}
 .slick-slide .image{padding:10px;}
 .slick-slide img{border:5px solid #FFF;display:block;width:100%;}
 .slick-slide img.slick-loading{border:0 }


### PR DESCRIPTION
If creating a carousel from elements used elsewhere, a 'clear' rule can trickle in and break the carousel.
This fix ensures that all slides are never cleared.