### PR TITLE
New feature: oneDotPerSlide

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -58,6 +58,7 @@ onBeforeChange(this, currentIndex,targetIndex) | method | null | Before slide ch
 onAfterChange(this, index) | method | null | After slide change callback
 onInit(this) | method | null | When Slick initializes for the first time callback
 onReInit(this) | method | null | Every time Slick (re-)initializes callback
+oneDotPerSlide | boolean | false | One navigation dot per slide (instead of one per slidesToShow slides)
 pauseOnHover | boolean | true | Pauses autoplay on hover
 pauseOnDotsHover | boolean | false | Pauses autoplay when a dot is hovered
 responsive | object | null | Breakpoint triggered settings

--- a/index.html
+++ b/index.html
@@ -410,7 +410,7 @@ $('.single-item-rtl').slick({
 				<p><strong>Note:</strong> the HTML tag or the parent of the slider must have the attribute "dir" set to "rtl".</p>
 				<hr />
 				<h2>One dot per slide</h2>
-				<div class="slider one-dot-per-class">
+				<div class="slider one-dot-per-slide">
 					<div><h3>1</h3></div>
 					<div><h3>2</h3></div>
 					<div><h3>3</h3></div>

--- a/index.html
+++ b/index.html
@@ -409,6 +409,24 @@ $('.single-item-rtl').slick({
 
 				<p><strong>Note:</strong> the HTML tag or the parent of the slider must have the attribute "dir" set to "rtl".</p>
 				<hr />
+				<h2>One dot per slide</h2>
+				<div class="slider one-dot-per-class">
+					<div><h3>1</h3></div>
+					<div><h3>2</h3></div>
+					<div><h3>3</h3></div>
+					<div><h3>4</h3></div>
+					<div><h3>5</h3></div>
+					<div><h3>6</h3></div>
+				</div>
+				<pre><code>
+$('.one-dot-per-slide').slick({
+    dots: true,
+    oneDotPerSlide: true,
+    slidesToShow: 3,
+    slidesToScroll: 1
+});
+				</code></pre>
+				<hr />
 				<h4 class="more">and a whole lot more...</h4>
 				</div>
 		</section>
@@ -636,6 +654,12 @@ $(document).ready(function(){
 							<td>function</td>
 							<td>null</td>
 							<td>Callback that fires after every re-initialization</td>
+						</tr>
+						<tr>
+							<td>oneDotPerSlide</td>
+							<td>boolean</td>
+							<td>false</td>
+							<td>One navigation dot per slide (instead of one per slidesToShow slides)</td>
 						</tr>
 						<tr>
 							<td>pauseOnHover</td>

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -187,5 +187,11 @@ $(document).ready(function() {
         slidesToScroll: 3,
         rtl: true
     });
+    $('.one-dot-per-slide').slick({
+        dots: true,
+        oneDotPerSlide: true,
+        slidesToShow: 3,
+        slidesToScroll: 1
+    });
 
 });

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -84,7 +84,8 @@
                 useCSS: true,
                 variableWidth: false,
                 vertical: false,
-                waitForAnimate: true
+                waitForAnimate: true,
+                oneDotPerSlide: false
             };
 
             _.initials = {
@@ -564,8 +565,17 @@
                 break;
 
             case 'index':
-                var index = event.data.index === 0 ? 0 :
-                    event.data.index || $(event.target).parent().index() * _.options.slidesToScroll;
+                var index;
+                if (typeof(event.data.index) === "number") {
+                    index = event.data.index;
+                } else if (_.options.oneDotPerSlide) {
+                    index = $(event.target).parent().index();
+                    if (!_.centerMode) {
+                        index = Math.max(0, Math.min(index - Math.floor(_.options.slidesToShow / 2), _.slideCount - _.options.slidesToShow));
+                    }
+                } else {
+                    index = $(event.target).parent().index() * _.options.slidesToScroll;
+                }
                 _.slideHandler(index);
 
             default:
@@ -688,6 +698,10 @@
             dotCounter = 0,
             dotCount = 0,
             dotLimit;
+
+        if (_.options.oneDotPerSlide) {
+            return _.slideCount - 1;
+        }
 
         dotLimit = _.options.infinite === true ? _.slideCount + _.options.slidesToShow - _.options.slidesToScroll : _.slideCount;
 
@@ -1768,7 +1782,24 @@
         if (_.$dots !== null) {
 
             _.$dots.find('li').removeClass('slick-active');
-            _.$dots.find('li').eq(Math.floor(_.currentSlide / _.options.slidesToScroll)).addClass('slick-active');
+
+            if (_.options.oneDotPerSlide) {
+                var start = _.options.centerMode
+                    ? _.currentSlide - Math.floor(_.options.slidesToShow / 2)
+                    : _.currentSlide;
+                if (_.options.infinite) {
+                    if (start > _.slideCount - _.options.slidesToShow) {
+                        start -= _.slideCount;
+                    }
+                }
+                _.$dots.find('li').filter(function() {
+                   var idx = $(this).index();
+                   return (idx >= start && idx < start + _.options.slidesToShow) || (_.options.infinite && idx - _.slideCount >= start && idx - _.slideCount < start + _.options.slidesToShow);
+                }).addClass('slick-active');
+
+            } else {
+                _.$dots.find('li').eq(Math.floor(_.currentSlide / _.options.slidesToScroll)).addClass('slick-active');
+            }
 
         }
 

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -570,8 +570,11 @@
                     index = event.data.index;
                 } else if (_.options.oneDotPerSlide) {
                     index = $(event.target).parent().index();
-                    if (!_.centerMode) {
-                        index = Math.max(0, Math.min(index - Math.floor(_.options.slidesToShow / 2), _.slideCount - _.options.slidesToShow));
+                    if (!_.options.centerMode) {
+                        index = index - Math.floor(_.options.slidesToShow / 2)
+                    }
+                    if (!_.options.infinite && !_.options.centerMode) {
+                        index = Math.max(0, Math.min(index, _.slideCount - _.options.slidesToShow));
                     }
                 } else {
                     index = $(event.target).parent().index() * _.options.slidesToScroll;


### PR DESCRIPTION

![slick-screenshot](https://cloud.githubusercontent.com/assets/357232/4524737/aaa0fc0a-4d48-11e4-9252-9de657258184.png)
Instead of one dot representing slidesToShow slides, they represent a
single slide, if the option oneDotPerSlide is set to true.