### PR TITLE
Fix responsive swiping edge cases

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1440,14 +1440,16 @@
 
         _.currentLeft = _.swipeLeft === null ? slideLeft : _.swipeLeft;
 
-        if (_.options.infinite === false && _.options.centerMode === false && (index < 0 || index > (_.slideCount - _.options.slidesToShow + unevenOffset))) {
-            if(_.options.fade === false) {
-                targetSlide = _.currentSlide;
-                _.animateSlide(slideLeft, function() {
-                    _.postSlide(targetSlide);
-                });
-            }
-            return false;
+        if (_.options.infinite === false && _.options.centerMode === false) {
+          if (index < 0) {
+            targetSlide = 0;
+            animSlide = 0
+            targetLeft = _.getLeft(targetSlide);
+          } else if (index > (_.slideCount - _.options.slidesToShow + unevenOffset)) {
+            targetSlide = _.slideCount - _options.slidesToShow + unevenOffset;
+            animSlide = targetSlide
+            targetLeft = _.getLeft(targetSlide);
+          }
         } else if (_.options.infinite === false && _.options.centerMode === true && (index < 0 || index > (_.slideCount - _.options.slidesToScroll))) {
             if(_.options.fade === false) {
                 targetSlide = _.currentSlide;


### PR DESCRIPTION
There was an issue with swiping the carousel beyond the number
of slides if not using infinite mode.  If you are using responsive
breakpoints, you could end up in a situation where you have fewer
remaining slides than your slidesToScroll value and attempt to go beyond
the slider.  When this happened, the user was brought back to where they
started.

This commit makes it so that if a user attempts to go beyond the end of
the carousel, they will go to the end of the list instead of back to where
they started.  Similarly, if a user attempts to go past the front of the
carousel, they will be taken to the start of the carousel.