### PR TITLE
Prevent initials.touchObject from being modified

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -108,11 +108,10 @@
                 slideOffset: 0,
                 swipeLeft: null,
                 $list: null,
-                touchObject: {},
                 transformsEnabled: false
             };
 
-            $.extend(_, _.initials);
+            _.setInitialValues();
 
             _.activeBreakpoint = null;
             _.animType = null;
@@ -804,6 +803,12 @@
 
     };
 
+    Slick.prototype.setInitialValues = function() {
+      var _ = this;
+      $.extend(_, _.initials);
+      _.touchObject = {};
+    }
+
     Slick.prototype.initArrowEvents = function() {
 
         var _ = this;
@@ -1058,7 +1063,7 @@
 
         _.destroy();
 
-        $.extend(_, _.initials);
+        _.setInitialValues();
 
         _.currentSlide = currentSlide;
         _.init();


### PR DESCRIPTION
_.initials.touchObject was being modified throughout the code because
$.extend was only making a reference to the object.  Anywhere that
_.touchObject was modified, _.initials.touchObject was modified as well.
This change instantiates a new object for _.touchObject each time.

This problem brought difficult-to-debug issues.  For example, when
breakpoints are met and checkResponsive triggers a refresh, the
touchObject after a refresh wasn't empty!  This led to unexpected slides
snapping on mousemove/mouseleave without actually clicking anything.