### PR TITLE
Update arrows when refreshing

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1062,6 +1062,7 @@
 
         _.currentSlide = currentSlide;
         _.init();
+        _.updateArrows();
 
     };
 


### PR DESCRIPTION
When moving between responsive breakpoints, the carousel was not always
displaying nav arrows appropriately.  If moving from one breakpoint to
another put you at the end of the carousel, the "next" arrow might
actually look like it's enabled, but if you click it then it suddenly
becomes disabled.

This ensures that the arrows are updated during a
refresh and display properly when switching between breakpoints.