### PR TITLE
add option to turn off lazy load animation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -58,6 +58,7 @@ prevArrow | string (html|jQuery selector) | object (DOM node|jQuery object) | <b
 nextArrow | string (html|jQuery selector) | object (DOM node|jQuery object) | <button type="button" class="slick-next">Next</button> | Allows you to select a node or customize the HTML for the "Next" arrow.
 infinite | boolean | true | Infinite looping
 initialSlide | integer | 0 | Slide to start on
+lazyAnimation | boolean | true | Fade in photos when lazy loading
 lazyLoad | string | 'ondemand' | Accepts 'ondemand' or 'progressive' for lazy load technique
 onBeforeChange(this, currentIndex,targetIndex) | method | null | Before slide change callback
 onAfterChange(this, index) | method | null | After slide change callback

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -66,6 +66,7 @@
                 infinite: true,
                 initialSlide: 0,
                 lazyLoad: 'ondemand',
+                lazyAnimation: true,
                 onBeforeChange: null,
                 onAfterChange: null,
                 onInit: null,
@@ -1013,8 +1014,8 @@
                     imageSource = $(this).attr('data-lazy');
 
                 image
-                  .load(function() { image.animate({ opacity: 1 }, 200); })
-                  .css({ opacity: 0 })
+                  .load(function() { if (_.options.lazyAnimation) { image.animate({ opacity: 1 }, 200); } })
+                  .css({ opacity: _.options.lazyAnimation ? 0 : 1 })
                   .attr('src', imageSource)
                   .removeAttr('data-lazy')
                   .removeClass('slick-loading');


### PR DESCRIPTION
i was occasionally running into issues with the opacity animation where the css would get set to 0 after transitioning to it. Then the animation wouldn't occur, or it had happened already, im not sure. Either way I was left with an invisible active image, because the opacity was 0. Didn't have time to figure out why, so I just added this option, which might be nice to have anyway.