### PR TITLE
Fix blurry text in some cases (Chrome)

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1151,8 +1151,8 @@
         if (_.options.rtl === true) {
             position = -position;
         }
-        x = _.positionProp == 'left' ? position + 'px' : '0px';
-        y = _.positionProp == 'top' ? position + 'px' : '0px';
+        x = _.positionProp == 'left' ? position.toFixed() + 'px' : '0px';
+        y = _.positionProp == 'top' ? position.toFixed() + 'px' : '0px';
 
         positionProps[_.positionProp] = position;
 


### PR DESCRIPTION
When "transform: translate3d" has not integer value like "-3001.5px" text is looking blurry in Chrome.
This fix it.