### PR TITLE
Feauture: Thumbnails mode

### DIFF
--- a/slick/slick.css
+++ b/slick/slick.css
@@ -69,9 +69,10 @@
     
     text-align: center;
     white-space: nowrap;
+    
 }
 
-.slick-thumbs, .slick-thumb, .slick-thumb img{
+.slick-thumbs, .slick-thumb{
     height: 100%;
 }
 
@@ -79,24 +80,22 @@
     position: relative;
     display: inline-block;
     vertical-align: top;
-    
-}
-.slick-thumb img {
-    display: block;
     max-height: 150px;
     border: 5px solid transparent;
 }
 
 .slick-thumb-frame {
+    border: 5px #633EBF solid; /* border need more then img border */
+    border-radius: 3px;
+}
+
+div.slick-thumb-frame {
     position: absolute;
     top: 0;
     left: -12px; /* to hide element | 12px = border-left + border-right*/
     
     height: 100%;
     z-index: 10;
-    background: rgba(99,62,191, 0.2);
-    border: 6px #633EBF solid; /* border need more then img border */
-    border-radius: 3px;
 }
 
 .slick-hide {

--- a/slick/slick.css
+++ b/slick/slick.css
@@ -70,6 +70,15 @@
     text-align: center;
     white-space: nowrap;
     
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    -ms-touch-action: pan-y;
+    touch-action: pan-y;
+    -webkit-tap-highlight-color: transparent;
 }
 
 .slick-thumbs, .slick-thumb{

--- a/slick/slick.css
+++ b/slick/slick.css
@@ -53,3 +53,52 @@
 [dir="rtl"] .slick-prev {right: -25px;left: auto;}
 [dir="rtl"] .slick-prev:before {content: "\2192";}
 [dir="rtl"] .slick-slide {float: right;}
+
+
+/* THUMBNAILS mode */
+.slick-thumbs-box {
+    display: block;
+    position: relative;
+    height: 100px; /* height = img height */
+}
+
+.slick-thumbs {
+    position: absolute;
+    overflow: hidden;
+    left: 0; right: 0;
+    
+    text-align: center;
+    white-space: nowrap;
+}
+
+.slick-thumbs, .slick-thumb, .slick-thumb img{
+    height: 100%;
+}
+
+.slick-thumb {
+    position: relative;
+    display: inline-block;
+    vertical-align: top;
+    
+}
+.slick-thumb img {
+    display: block;
+    max-height: 150px;
+    border: 5px solid transparent;
+}
+
+.slick-thumb-frame {
+    position: absolute;
+    top: 0;
+    left: -12px; /* to hide element | 12px = border-left + border-right*/
+    
+    height: 100%;
+    z-index: 10;
+    background: rgba(99,62,191, 0.2);
+    border: 6px #633EBF solid; /* border need more then img border */
+    border-radius: 3px;
+}
+
+.slick-hide {
+    display: none;
+}

--- a/slick/slick.css
+++ b/slick/slick.css
@@ -56,6 +56,10 @@
 
 
 /* THUMBNAILS mode */
+.slick-hide {
+    display: none;
+}
+
 .slick-thumbs-box {
     display: block;
     position: relative;
@@ -76,8 +80,6 @@
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
-    -ms-touch-action: pan-y;
-    touch-action: pan-y;
     -webkit-tap-highlight-color: transparent;
 }
 
@@ -89,24 +91,57 @@
     position: relative;
     display: inline-block;
     vertical-align: top;
-    max-height: 150px;
     border: 5px solid transparent;
 }
 
 .slick-thumb-frame {
-    border: 5px #633EBF solid; /* border need more then img border */
+    border: 5px #633EBF solid;
     border-radius: 3px;
 }
 
 div.slick-thumb-frame {
     position: absolute;
     top: 0;
-    left: -12px; /* to hide element | 12px = border-left + border-right*/
+    left: -10px; /* to hide element */
     
     height: 100%;
     z-index: 10;
 }
 
-.slick-hide {
-    display: none;
+/* vertical mode */
+.slick-thumbs-box-vertical {
+    height: auto;
+    width: 100px; /* width = img width */
+}
+
+.slick-thumbs-box-vertical .slick-thumbs {
+    white-space: normal;
+    top: 0;
+    bottom: 0;
+    margin: auto;
+}
+
+.slick-thumbs-box-vertical .slick-thumbs-measure {
+    bottom: auto;
+    visibility: hidden;
+    height: auto !important;
+}
+
+.slick-thumbs-box-vertical .slick-thumb {
+    height: auto;
+    width: 100%;
+    max-height: none;
+}
+
+.slick-thumbs-box-vertical div.slick-thumb-frame {
+    left: 0;
+    height: auto;
+    width: 100%;
+}
+
+.slick-vertical .slick-thumbs-box-vertical {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    margin-left: 100%; /* not right -100px, to avoid container width restriction */
 }

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -445,8 +445,7 @@
         var _ = this,
             i, length = _.$slides.length,
             thumbs = [], thumb, srcList = [],
-            container = _.options.appendThumbs,
-            images = {}, index;
+            container, images = {}, index;
 
         if (_.options.thumbs === true) {
 
@@ -459,12 +458,10 @@
             }
 
             if (thumbs.length == length) {
-            
-                if ( container.get(0) == _.$slider.get(0)) {
-                    _.options.appendThumbs = container = $('<div></div>').appendTo(container);
-                }
+                container = _.options.appendThumbs.find('div.slick-thumbs-box').get(0)
+                    ? _.options.appendThumbs.find('div.slick-thumbs-box')
+                    : $('<div class="slick-thumbs-box"/>').appendTo(_.options.appendThumbs);
 
-                container.addClass('slick-thumbs-box');
                 if (_.options.vertical === true) {
                     container.addClass('slick-thumbs-box-vertical');
                 } else {
@@ -708,13 +705,15 @@
 
         _.touchObject = {};
 
+        _.thumbsParams = {};
+
         $('.slick-cloned', _.$slider).remove();
         if (_.$dots) {
             _.$dots.remove();
         }
         
         if (_.$thumbs) {
-            _.options.appendThumbs.empty();
+            _.$thumbs.parent('.slick-thumbs-box').remove();
         }
 
         if (_.$prevArrow) {
@@ -976,7 +975,7 @@
             timers = { left: 0, right: 0 },
             key;
 
-        if (_.options.thumbs === true && _.slideCount > _.options.slidesToShow) {
+        if (_.$thumbs && _.slideCount > _.options.slidesToShow) {
             // prevent doubled event
             $('img.slick-thumb', _.$thumbs).each(function(num){
                 ! $(this).data('events') && $(this).on('click.slick', { message: 'index', index: num }, _.changeSlide);

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -115,6 +115,7 @@
                 slideOffset: 0,
                 swipeLeft: null,
                 $list: null,
+                filtered: null,
                 touchObject: {},
                 thumbsParams: {},
                 transformsEnabled: false
@@ -475,18 +476,26 @@
                     images = _.$thumbs.find('img');
                     for(i = 0; i < images.length; i++) {
                         index = $.inArray(images[i].getAttribute('src'), srcList);
-                        if (index == -1) {
-                            $(images[i]).remove();
+
+                        if (index == -1 || _.filtered === false) {
+                            // remove elements if slides < thumbs || remove all elements when unfiltered
+                            $(images[i]).off('click.slick');
+                            images[i].parentNode.removeChild(images[i]);
                         } else {
                             // remove duplicates
                             thumbs[index] = srcList[index] = '';
+                        }
+
+                        if (_.filtered === true) {
+                            // remove events when filtered
+                            $(images[i]).off('click.slick');
                         }
                     }
                 } else {
                     _.$thumbs = $('<div class="' +_.options.thumbsClass+ '">'
                         +'</div>').appendTo(container);
                 }
-                // apend only new thumbnails
+                // append only new thumbnails
                 _.$thumbs.get(0).insertAdjacentHTML('beforeend', thumbs.join(''));
                 
                 if (_.options.thumbFrame) {
@@ -792,6 +801,8 @@
         var _ = this;
 
         if (filter !== null) {
+
+            _.filtered = true;
 
             _.unload();
 
@@ -1956,6 +1967,8 @@
         var _ = this;
 
         if (_.$slidesCache !== null) {
+
+            _.filtered = false;
 
             _.unload();
 

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -514,8 +514,6 @@
                 _.$thumbs.find('img').eq(_.currentSlide).load(function(){   
                     _.updateThumbs( this.parentNode.offsetWidth, this.parentNode.offsetLeft);
                 });
-
-                _.updateThumbArrows();
             }
         }
     };
@@ -1010,7 +1008,7 @@
                     _.windowWidth = $(window).width();
                     _.checkResponsive();
                     _.setPosition();
-                    _.updateThumbArrows();
+                    _.updateThumbs();
                 }, 50);
             }
         });
@@ -1946,6 +1944,7 @@
                     left:  left || thumb.offsetLeft 
                 });
             }
+            _.updateThumbArrows();
         }
     };
 
@@ -1954,7 +1953,7 @@
         var _ = this,
             key, $el;
 
-        if (_.options.thumbArrows) {
+        if ( _.options.thumbArrows == true && _.$thumbs !== null) {
             $el = _.$thumbs.get(0);
 
             if ($el.scrollWidth > $el.clientWidth) {


### PR DESCRIPTION
Simple thumbnails mode.

**Demo**: http://jaaah.github.io/slick/thumbnails.html

![Thumbnails mode](http://i.imgur.com/jtJ9PEf.jpg)

This mode is useful when the Slick used for carousel images.
Thumbs mode similar to dots mode.

Tried to make this scenario with two synced Slick instances, but attempt failed.