### PR TITLE
Vertical mode with different slide heights

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1182,7 +1182,11 @@
                 });
             }
         } else {
-            _.$list.height(_.$slides.first().outerHeight(true) * _.options.slidesToShow);
+            _.slideHeight = Math.max.apply( null, _.$slider.find('.slick-slide').map(function() { return $(this).height() }) )
+            _.$slideTrack.children('.slick-slide').height(_.slideHeight);
+
+            _.$list.height(_.slideHeight * _.options.slidesToShow);
+
             if (_.options.centerMode === true) {
                 _.$list.css({
                     padding: (_.options.centerPadding + ' 0px')
@@ -1211,7 +1215,6 @@
 
         var offset = _.$slides.first().outerWidth(true) - _.$slides.first().width();
         if (_.options.variableWidth === false) _.$slideTrack.children('.slick-slide').width(_.slideWidth - offset);
-
     };
 
     Slick.prototype.setFade = function() {


### PR DESCRIPTION
I was having issues with slides of different heights in vertical mode.
The track would advance the height of the first slide, but the slides
were different heights, which meant they were out of sync with the
track.

This patch adds a quick check in `setDimensions` for vertical mode, and
if set, finds the tallest slide and sets all slides equal to that
height. It also sets the list height accordingly.
