### PR TITLE
Add spm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "slick-carousel",
+    "name": "slick",
     "version": "1.3.11",
     "description": "the last carousel you'll ever need",
     "main": "slick/slick.js",
@@ -16,5 +16,16 @@
     "license": "MIT",
     "bugs": {
         "url": "https://github.com/kenwheeler/slick/issues"
+    },
+    "spm": {
+        "main": "slick/slick.js",
+        "dependencies": {
+            "jquery": "1.7.2"
+        },
+        "ignore": [
+            "css",
+            "js",
+            "img"
+        ]
     }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/slick

---

It is a package manager based on [Sea.js](https://github.com/seajs/seajs) which is a popular module loader in China.

spmjs focus in browser side. We supply a complete lifecycle managment of package by using [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of slick in spmjs, I can add it for your account after signing in http://spmjs.io.