### PR TITLE
If centerMode is true, no longer sets scrollToShow to 1.

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -457,7 +457,6 @@
         _.$slideTrack.css('opacity', 0);
 
         if (_.options.centerMode === true) {
-            _.options.slidesToScroll = 1;
             if (_.options.slidesToShow % 2 === 0) {
                 _.options.slidesToShow = 3;
             }


### PR DESCRIPTION
Hoping to resolve https://github.com/kenwheeler/slick/issues/541, but would like to confirm that this doesn't affect any other settings.