### PR TITLE
Fix progressive lazy loading issue

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1100,7 +1100,7 @@
         var _ = this,
             imgCount, targetImage;
 
-        imgCount = $('img[data-lazy]').length;
+        imgCount = $('img[data-lazy]', _.$slider).length;
 
         if (imgCount > 0) {
             targetImage = $('img[data-lazy]', _.$slider).first();


### PR DESCRIPTION
Having multiple slick carousels on a page with lazy loading causes the progressive lazy loader to miscount the number of slides which in turn causes older jquery to throw an error when setting the attribute of the empty node. This fixes the issue.

Issue:
http://jsfiddle.net/z9j9w4ks/

Only happens with older jquery versions (1.6) so feel free to ignore this
