### PR TITLE
adding calculation for carousel width in breakpoints

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -493,6 +493,8 @@
 
         var _ = this,
             breakpoint, targetBreakpoint, respondToWidth;
+        var sliderWidth = _.$slider.width();
+        var windowWidth = $(window).width();
         if (_.respondTo === "window") {
           respondToWidth = windowWidth;
         } else if (_.respondTo === "slider") {


### PR DESCRIPTION
The breakpoints in slick are better suited for Walmart.com carousels if
we let them adjust based on carousel width in addition to window width.
