### PR TITLE
Remove indexOf in navigables logic for ie8 support

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -583,7 +583,7 @@
 
                 navigables = _.getNavigableIndexes();
                 prevNavigable = 0;
-                if(navigables.indexOf(index) === -1) {
+                if(navigables[index] && navigables[index] === index) {
                     if(index > navigables[navigables.length -1]){
                         index = navigables[navigables.length -1];
                     } else {


### PR DESCRIPTION
indexOf isn't working as expected in ie8, this switches the method of the "navigables" index check for legacy support

http://stackoverflow.com/questions/3629183/why-doesnt-indexof-work-on-an-array-ie8
