### PR TITLE
Add reinit on specific slide

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -226,8 +226,14 @@
         });
 
         _.$slidesCache = _.$slides;
-
-        _.reinit();
+        
+        if(addBefore){
+        	_.reinit(1);
+        }
+        else{
+        	_.reinit();
+        }
+        
 
     };
 
@@ -1189,7 +1195,7 @@
 
     };
 
-    Slick.prototype.reinit = function() {
+    Slick.prototype.reinit = function(index) {
 
         var _ = this;
 
@@ -1204,6 +1210,10 @@
 
         if (_.slideCount <= _.options.slidesToShow) {
             _.currentSlide = 0;
+        }
+        
+        if(index!==undefined){
+        	_.currentSlide = index;
         }
 
         _.setProps();


### PR DESCRIPTION
Allow reinit of Slick to specify a current slide to address the issue when a slide is inserted at the beginning of the carousel dynamically on "previous" click.  This allows lazy-loading of very long carousels.
https://github.com/kenwheeler/slick/issues/303
