### PR TITLE
Alternative loadImage method for the lazyLoad functionality

### DIFF
--- a/slick/slick.css
+++ b/slick/slick.css
@@ -1,4 +1,3 @@
-@charset "UTF-8";
 /* Slider */
 .slick-slider {
   position: relative;
@@ -24,7 +23,7 @@
   .slick-list:focus {
     outline: none; }
   .slick-loading .slick-list {
-    background: #fff url("./ajax-loader.gif") center center no-repeat; }
+    background: white image-url("ajax-loader.gif", false, false) center center no-repeat; }
   .slick-list.dragging {
     cursor: pointer;
     cursor: hand; }
@@ -71,14 +70,20 @@
     display: block;
     height: auto;
     border: 1px solid transparent; }
+  .slick-slide .autoFitImage {
+    background-position: center center;
+    background-size: cover;
+    background-repeat: no-repeat;
+    margin: auto; }
 
 /* Icons */
 @font-face {
   font-family: "slick";
-  src: url("./fonts/slick.eot");
-  src: url("./fonts/slick.eot?#iefix") format("embedded-opentype"), url("./fonts/slick.woff") format("woff"), url("./fonts/slick.ttf") format("truetype"), url("./fonts/slick.svg#slick") format("svg");
+  src: font-url("slick.eot");
+  src: font-url("slick.eot?#iefix") format("embedded-opentype"), font-url("slick.woff") format("woff"), font-url("slick.ttf") format("truetype"), font-url("slick.svg#slick") format("svg");
   font-weight: normal;
   font-style: normal; }
+
 /* Arrows */
 .slick-prev,
 .slick-next {
@@ -125,9 +130,9 @@
     left: auto;
     right: -25px; }
   .slick-prev:before {
-    content: "←"; }
+    content: "\2190"; }
     [dir="rtl"] .slick-prev:before {
-      content: "→"; }
+      content: "\2192"; }
 
 .slick-next {
   right: -25px; }
@@ -135,9 +140,9 @@
     left: -25px;
     right: auto; }
   .slick-next:before {
-    content: "→"; }
+    content: "\2192"; }
     [dir="rtl"] .slick-next:before {
-      content: "←"; }
+      content: "\2190"; }
 
 /* Dots */
 .slick-slider {
@@ -179,7 +184,7 @@
         position: absolute;
         top: 0;
         left: 0;
-        content: "•";
+        content: "\2022";
         width: 20px;
         height: 20px;
         font-family: "slick";

--- a/slick/slick.css
+++ b/slick/slick.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /* Slider */
 .slick-slider {
   position: relative;
@@ -23,7 +24,7 @@
   .slick-list:focus {
     outline: none; }
   .slick-loading .slick-list {
-    background: white image-url("ajax-loader.gif", false, false) center center no-repeat; }
+    background: #fff url("./ajax-loader.gif") center center no-repeat; }
   .slick-list.dragging {
     cursor: pointer;
     cursor: hand; }
@@ -70,20 +71,14 @@
     display: block;
     height: auto;
     border: 1px solid transparent; }
-  .slick-slide .autoFitImage {
-    background-position: center center;
-    background-size: cover;
-    background-repeat: no-repeat;
-    margin: auto; }
 
 /* Icons */
 @font-face {
   font-family: "slick";
-  src: font-url("slick.eot");
-  src: font-url("slick.eot?#iefix") format("embedded-opentype"), font-url("slick.woff") format("woff"), font-url("slick.ttf") format("truetype"), font-url("slick.svg#slick") format("svg");
+  src: url("./fonts/slick.eot");
+  src: url("./fonts/slick.eot?#iefix") format("embedded-opentype"), url("./fonts/slick.woff") format("woff"), url("./fonts/slick.ttf") format("truetype"), url("./fonts/slick.svg#slick") format("svg");
   font-weight: normal;
   font-style: normal; }
-
 /* Arrows */
 .slick-prev,
 .slick-next {
@@ -130,9 +125,9 @@
     left: auto;
     right: -25px; }
   .slick-prev:before {
-    content: "\2190"; }
+    content: "←"; }
     [dir="rtl"] .slick-prev:before {
-      content: "\2192"; }
+      content: "→"; }
 
 .slick-next {
   right: -25px; }
@@ -140,9 +135,9 @@
     left: -25px;
     right: auto; }
   .slick-next:before {
-    content: "\2192"; }
+    content: "→"; }
     [dir="rtl"] .slick-next:before {
-      content: "\2190"; }
+      content: "←"; }
 
 /* Dots */
 .slick-slider {
@@ -184,7 +179,7 @@
         position: absolute;
         top: 0;
         left: 0;
-        content: "\2022";
+        content: "•";
         width: 20px;
         height: 20px;
         font-family: "slick";

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -66,6 +66,7 @@
                 infinite: true,
                 initialSlide: 0,
                 lazyLoad: 'ondemand',
+				autoFitImage: false,
                 onBeforeChange: null,
                 onAfterChange: null,
                 onInit: null,
@@ -1060,20 +1061,45 @@
         var _ = this,
             loadRange, cloneRange, rangeStart, rangeEnd;
 
-        function loadImages(imagesScope) {
-            $('img[data-lazy]', imagesScope).each(function() {
-                var image = $(this),
-                    imageSource = $(this).attr('data-lazy');
+		var loadImages;
+		if(_.options.autoFitImage)
+        {
+            loadImages = function(imagesScope) {
+                $('div[data-lazy]', imagesScope).each(function() {
+                    var imageSrc = $(this).attr('data-lazy');
+                    var div = $(this);
 
-                image
-                  .load(function() { image.animate({ opacity: 1 }, 200); })
-                  .css({ opacity: 0 })
-                  .attr('src', imageSource)
-                  .removeAttr('data-lazy')
-                  .removeClass('slick-loading');
-            });
+                    div.css({ opacity: 0 });
+
+                    //Only show image once it's loaded
+                    $('<img/>').attr('src', imageSrc).load(function() {
+                        $(this).remove();
+
+                        div
+                            .css('background-image', 'url('+imageSrc+')')
+                            .animate({ opacity: 1 }, 200)
+                            .removeAttr('data-lazy');
+                    });
+                });
+            }
         }
+		else
+		{
+			loadImages = function(imagesScope) {
+				$('img[data-lazy]', imagesScope).each(function() {
+					var image = $(this),
+						imageSource = $(this).attr('data-lazy');
 
+					image
+					  .load(function() { image.animate({ opacity: 1 }, 200); })
+					  .css({ opacity: 0 })
+					  .attr('src', imageSource)
+					  .removeAttr('data-lazy')
+					  .removeClass('slick-loading');
+				});
+			}
+		}
+		
         if (_.options.centerMode === true) {
             if (_.options.infinite === true) {
                 rangeStart = _.currentSlide + (_.options.slidesToShow/2 + 1);
@@ -1094,10 +1120,10 @@
         loadRange = _.$slider.find('.slick-slide').slice(rangeStart, rangeEnd);
         loadImages(loadRange);
 
-          if (_.slideCount <= _.options.slidesToShow){
-              cloneRange = _.$slider.find('.slick-slide')
-              loadImages(cloneRange)
-          }else
+        if (_.slideCount <= _.options.slidesToShow){
+            cloneRange = _.$slider.find('.slick-slide')
+            loadImages(cloneRange)
+        }else
         if (_.currentSlide >= _.slideCount - _.options.slidesToShow) {
             cloneRange = _.$slider.find('.slick-cloned').slice(0, _.options.slidesToShow);
             loadImages(cloneRange)

--- a/slick/slick.scss
+++ b/slick/slick.scss
@@ -134,6 +134,13 @@ $slick-opacity-not-active: .25 !default;
         height: auto;
         border: 1px solid transparent;
     }
+
+	.autoFitImage {
+		background-position: center center;
+		background-size: cover;
+		background-repeat: no-repeat;
+		margin: auto;
+	}
 }
 
 /* Icons */


### PR DESCRIPTION
A while back I wrote a different method for loading images. Rather than using the `<img>` tag I use a `<div>` tag. The image (still specified in data-lazy) is loaded into the divs background. This allows me to center and zoom the background image to fit the size of the div.

  * It is important that the dimensions of the div where specified otherwise nothing will show.
  * The div should also have the class `autoFitImage`

This allows Slick to consistently display a carousel containing images with different dimensions without having to stretch them. I wrote this because I'm dynamically generating carousels from images provided by the user(s).

Example of a slide:
```
<div>
	<div class="autoFitImage <class-with-div-size>" data-lazy="<img-src>"></div>
</div>
```

Small note; I never really worked with scss so not sure if I added the autoFitImage class correctly. I didn’t compile the scss file since it came back containing more changes than just mine. Think you might be using a different scss compiler. The file needs to be compiled before my .autoFitImage class is added to the .css file.

Not sure if you are interested in this method, or if it is appropriate for the project. But thought I should share it.

If you're not happy with this method an alternative solution would be to make the `loadImages` function an option so it is over writable. Let me know what you think.