### PR TITLE
add option to allow prevention of autoplay from reversing slide direction

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -42,6 +42,7 @@ Option | Type | Default | Description
 accessibility | boolean | true | Enables tabbing and arrow key navigation
 autoplay | boolean | false | Enables auto play of slides
 autoplaySpeed | int  | 3000 | Auto play change interval
+autoplayChangeDirection | boolean  | true | Change direction when reaching the final slide when autoplay is enabled and infinite looping is disabled.
 centerMode | boolean | false | Enables centered view with partial prev/next slides. Use with odd numbered slidesToShow counts.
 centerPadding | string | '50px' | Side padding when in center mode. (px or %)
 cssEase | string |  'ease' | CSS3 easing

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -51,6 +51,7 @@
                 nextArrow: '<button type="button" data-role="none" class="slick-next">Next</button>',
                 autoplay: false,
                 autoplaySpeed: 3000,
+                autoplayChangeDirection: true,
                 centerMode: false,
                 centerPadding: '50px',
                 cssEase: 'ease',
@@ -363,7 +364,7 @@
 
         if (_.options.infinite === false) {
 
-            if (_.direction === 1) {
+            if (_.direction === 1 || _.options.autoplayChangeDirection === false) {
 
                 if ((_.currentSlide + 1) === _.slideCount -
                     1) {


### PR DESCRIPTION
A number of sites will typically advertise related or "up next" news items/galleries/etc. after the final slide, and that was the use case I was considering when writing this update. The only way I could think of to do this is currently is put a check in the onAfterChange callback to see if the user tried to advance past the last slide, and if so, display an interstitial of sorts. However, when in autoplay mode, this would never happen because the direction would reverse. I just wanted to add this option so that the carousel would attempt to advance past the last slide, and I could check for that condition and handle it however I wanted, also being able to pause it in that state as well.