### PR TITLE
adapativeheight to work when fade = true

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -230,15 +230,20 @@
         _.reinit();
 
     };
+	
+	Slick.prototype.animateHeight = function(){
+		var _ = this;
+		if(_.options.slidesToShow === 1 && _.options.adaptiveHeight === true && _.options.vertical === false) {
+            var targetHeight = _.$slides.eq(_.currentSlide).outerHeight(true);
+            _.$list.animate({height: targetHeight},_.options.speed);
+        }
+	};
 
     Slick.prototype.animateSlide = function(targetLeft, callback) {
 
         var animProps = {}, _ = this;
 
-        if(_.options.slidesToShow === 1 && _.options.adaptiveHeight === true && _.options.vertical === false) {
-            var targetHeight = _.$slides.eq(_.currentSlide).outerHeight(true);
-            _.$list.animate({height: targetHeight},_.options.speed);
-        }
+		_.animateHeight();
 
         if (_.options.rtl === true && _.options.vertical === false) {
             targetLeft = -targetLeft;
@@ -1678,6 +1683,7 @@
             } else {
                 _.postSlide(animSlide);
             }
+			_.animateHeight();
             return;
         }
 


### PR DESCRIPTION
Previously if the fade option was true, the adaptive height was ignored.
Extracting the animation code into a separate function we can now call
animateHeight before the slidehandler function is returned.