### PR TITLE
Explain lazyload parameters

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -58,7 +58,7 @@ prevArrow | string (html|jQuery selector) | object (DOM node|jQuery object) | <b
 nextArrow | string (html|jQuery selector) | object (DOM node|jQuery object) | <button type="button" class="slick-next">Next</button> | Allows you to select a node or customize the HTML for the "Next" arrow.
 infinite | boolean | true | Infinite looping
 initialSlide | integer | 0 | Slide to start on
-lazyLoad | string | 'ondemand' | Accepts 'ondemand' or 'progressive' for lazy load technique
+lazyLoad | string | 'ondemand' | Accepts 'ondemand' or 'progressive' for lazy load technique. 'ondemand' will load the image as soon as you slide to it, 'progressive' loads one image after the other when the page loads.
 onBeforeChange(this, currentIndex,targetIndex) | method | null | Before slide change callback
 onAfterChange(this, index) | method | null | After slide change callback
 onInit(this) | method | null | When Slick initializes for the first time callback


### PR DESCRIPTION
Added explanation for lazyLoad parameters, since the difference between `ondemand` and `progressive` were not explained in the docs. Found an explanation in #637