### PR TITLE
Force repositioning after progressive loading

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1160,6 +1160,10 @@
             targetImage.attr('src', targetImage.attr('data-lazy')).removeClass('slick-loading').load(function() {
                 targetImage.removeAttr('data-lazy');
                 _.progressiveLazyLoad();
+                
+                if( _.options.adaptiveHeight === true ) {
+                    _.setPosition();
+                }
             })
          .error(function () {
           targetImage.removeAttr('data-lazy');


### PR DESCRIPTION
At the moment slider doesn't force recalculating of slide's dimensions with `lazyLoad:'progressive'` in combination with `adaptiveHeight:true`.