### PR TITLE
Note about event listener before initialization

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -105,7 +105,7 @@ waitForAnimate | boolean | true | Ignores requests to advance the slide while an
 
 ### Events
 
-In slick 1.4, callback methods have been deprecated and replaced with events. Use them as shown below:
+In slick 1.4, callback methods have been deprecated and replaced with events. Use them before the initialization of slick as shown below:
 
 ```javascript
 // On swipe event


### PR DESCRIPTION
For the init and reInit event to work correct the event listeners have to be added before initialization of slick. Added a note to the readme. #970