### PR TITLE
No need to do this

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -320,12 +320,7 @@
                 _.$slideTrack.css(animProps);
 
                 if (callback) {
-                    setTimeout(function() {
-
-                        _.disableTransition();
-
-                        callback.call();
-                    }, _.options.speed);
+                    callback.call();
                 }
 
             }


### PR DESCRIPTION
Causing delay in the index change when slides are changed frequently using external control.