### PR TITLE
Quick one: Update slick.js - insert a reset of the touchObject in prototype.render

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1315,7 +1315,9 @@
                 index: currentSlide
             }
         }, true);
-
+          
+        _.touchObject = {};
+          
     };
 
     Slick.prototype.reinit = function() {


### PR DESCRIPTION
This simple fix prevent this problem:
1) drag with mouse the carousel.
2) refresh the carousel using console: $('.carousel').getSlick().refresh()
3) enter the carousel and leave it with the mouse.
4) the carousel will slide!!!!!

solution:
reset the touchObject in the refresh method