### PR TITLE
fix #1043

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1701,7 +1701,8 @@
     Slick.prototype.selectHandler = function(event) {
 
         var _ = this;
-        var index = parseInt($(event.target).parents('.slick-slide').attr("data-slick-index"));
+        var slide = $(event.target).parents('.slick-slide');
+        var index = $(event.target).parents('.slick-track').children().index(slide);
         if(!index) index = 0;
 
         if(_.slideCount <= _.options.slidesToShow){


### PR DESCRIPTION
in synced sliders, use natural ordering of slides instead of data-slick-index to navigate with mouse clicks, cos filtering could be applied