### PR TITLE
Remove getNavigableIndexes counter assignment, which caused Chrome to crash when setting slidesToShow option dynamically

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -904,7 +904,6 @@
             if (_.options.centerMode === true) max = _.slideCount;
         } else {
             breakPoint = _.slideCount * -1;
-            counter = _.slideCount * -1;
             max = _.slideCount * 2;
         }
 
@@ -1285,7 +1284,7 @@
             targetImage.attr('src', targetImage.attr('data-lazy')).removeClass('slick-loading').load(function() {
                 targetImage.removeAttr('data-lazy');
                 _.progressiveLazyLoad();
-                
+
                 if( _.options.adaptiveHeight === true ) {
                     _.setPosition();
                 }


### PR DESCRIPTION
This pull request fixes an issue that causes Chrome to crash when dynamically setting the slidesToShow and slidesToScroll options dynamically. To reproduce the problem in the fiddle, resize your browser to the smallest breakpoint, then increase the window size. Chrome should crash.

http://jsfiddle.net/7uzkbeoj/2/