### PR TITLE
fix a bug with page visibility triggered pausing on IE10/11

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -166,9 +166,6 @@
             if (typeof document.mozHidden !== "undefined") {
                 _.hidden = "mozHidden";
                 _.visibilityChange = "mozvisibilitychange";
-            } else if (typeof document.msHidden !== "undefined") {
-                _.hidden = "msHidden";
-                _.visibilityChange = "msvisibilitychange";
             } else if (typeof document.webkitHidden !== "undefined") {
                 _.hidden = "webkitHidden";
                 _.visibilityChange = "webkitvisibilitychange";


### PR DESCRIPTION
#927 - fixes this issue.
Tested in IE10 and IE11.
Bug was due to me blindly following an out-of-date Mozilla Dev guide: https://developer.mozilla.org/en-US/docs/Web/Guide/User_experience/Using_the_Page_Visibility_API where it incorrectly states "msvisibilitychange" as the event listener/handler for IE :disappointed: , after checking https://msdn.microsoft.com/library/ie/hh673553 it's clearly not the case. And tested, works as expected. :smile: 