### PR TITLE
Fix issue when using customPaging

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -452,7 +452,7 @@
             dotString = '<ul class="' + _.options.dotsClass + '">';
 
             for (i = 0; i <= _.getDotCount(); i += 1) {
-                dotString += '<li>' + _.options.customPaging.call(this, _, i) + '</li>';
+                dotString += '<li class="dot">' + _.options.customPaging.call(this, _, i) + '</li>';
             }
 
             dotString += '</ul>';
@@ -623,7 +623,7 @@
 
             case 'index':
                 var index = event.data.index === 0 ? 0 :
-                    event.data.index || $(event.target).parents('li').index() * _.options.slidesToScroll;
+                    event.data.index || $(event.target).parents('.dot').index() * _.options.slidesToScroll;
 
                 _.slideHandler(_.checkNavigable(index), false, dontAnimate);
                 break;

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -623,7 +623,7 @@
 
             case 'index':
                 var index = event.data.index === 0 ? 0 :
-                    event.data.index || $(event.target).parent().index() * _.options.slidesToScroll;
+                    event.data.index || $(event.target).parents('li').index() * _.options.slidesToScroll;
 
                 _.slideHandler(_.checkNavigable(index), false, dontAnimate);
                 break;


### PR DESCRIPTION
This fix when using customPaging and change the html structure.

Problem: when you click in the child element of the <li>  the plugin look for the parent of the even.target and try to get the index.
Solution: Could use the event.currentTarget but for fallback compatibility ( < IE 8 ), I changed to look for the parents('.dot')

Here is the example:
http://jsfiddle.net/binwilly/sp2c342f/
If you click in the blue zone works as expected because is the <li> element, but in the <p> (red) always go to the first slide.