### PR TITLE
asNavFor when `infinite` is false prevent dyssynchrony

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -336,6 +336,13 @@
 
     Slick.prototype.asNavFor = function(index) {
         var _ = this, asNavFor = _.options.asNavFor !== null ? $(_.options.asNavFor).slick('getSlick') : null;
+
+        if (index < 0) {
+            index = 0;
+        } else if (index > _.$slides.length - 1) {
+            index = _.$slides.length - 1;
+        }
+        
         if(asNavFor !== null) asNavFor.slideHandler(index, true);
     };
 


### PR DESCRIPTION
I found a bug when setting infinite to false, for asNavFor. If I try to swipe further left or right on the boundaries the child parent loses synchrony by going up an index or down an index. This is a small fix for it.