### PR TITLE
Fix: pauseOnHover re-starts a paused carousel

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1043,26 +1043,24 @@
 
         _.$list.on('click.slick', _.clickHandler);
 
-        if (_.options.autoplay === true) {
-
-            $(document).on(_.visibilityChange, function(){
+        $(document).on(_.visibilityChange, function(){
+            if (_.options.autoplay === true) {
                 _.visibility();
-            });
-
-            if( _.options.pauseOnHover === true ) {
-
-                _.$list.on('mouseenter.slick', function(){
-                    _.paused = true;
-                    _.autoPlayClear();
-                });
-                _.$list.on('mouseleave.slick', function(){
-                    _.paused = false;
-                    _.autoPlay();
-                });
-
             }
+        });
 
-        }
+        _.$list.on('mouseenter.slick', function(){
+            if (_.options.autoplay === true && _.options.pauseOnHover === true) {
+                _.paused = true;
+                _.autoPlayClear();
+            }
+        });
+        _.$list.on('mouseleave.slick', function(){
+            if (_.options.autoplay === true && _.options.pauseOnHover === true) {
+                _.paused = false;
+                _.autoPlay();
+            }
+        });
 
         if(_.options.accessibility === true) {
             _.$list.on('keydown.slick', _.keyHandler);


### PR DESCRIPTION
I needed a way to pause my Slick carousel temporarily. I have `pauseOnHover` set on the carousel. To pause the carousel, I run something like this:

```js
			$(this)
				.slick('slickPause')
				.slick('slickSetOption', 'pauseOnHover', false);

```

However, because the events are registered when the plugin gets initialised, they don't respect changes to the settings. As such, even after running this code I can re-start the carousel by hovering on it then moving my mouse elsewhere.

To resolve this, I moved the if statements inside the event listeners.

This is probably an issue for a handful of other settings, too.

JSFiddle showing the bug: http://jsfiddle.net/15h172h1/

Same JSFiddle with my forked version of Slick: http://jsfiddle.net/a9pm4oL5/1/