### PR TITLE
add infiniteAutoplay option

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -65,6 +65,7 @@
                 fade: false,
                 focusOnSelect: false,
                 infinite: true,
+                infiniteAutoplay: true,
                 initialSlide: 0,
                 lazyLoad: 'ondemand',
                 mobileFirst: false,
@@ -390,9 +391,20 @@
 
             if (_.direction === 1) {
 
-                if ((_.currentSlide + 1) === _.slideCount -
-                    1) {
-                    _.direction = 0;
+                if ((_.currentSlide + 1) === _.slideCount - 1) {
+
+                    if (_.options.infiniteAutoplay === true) {
+
+                        _.direction = 0;
+
+                    } else {
+
+                        if (_.autoPlayTimer) {
+
+                            clearInterval(_.autoPlayTimer);
+
+                        } 
+                    }
                 }
 
                 _.slideHandler(_.currentSlide + _.options.slidesToScroll);
@@ -401,7 +413,18 @@
 
                 if ((_.currentSlide - 1 === 0)) {
 
-                    _.direction = 1;
+                    if (_.options.infiniteAutoplay === true) {
+
+                        _.direction = 1;
+
+                    } else {
+                        
+                        if (_.autoPlayTimer) {
+
+                            clearInterval(_.autoPlayTimer);
+
+                        } 
+                    }
 
                 }
 


### PR DESCRIPTION
If infinite is false, I would meet a problem when I apply autoplay. I want to set infinite as false is because it will stop when Carousel at the last page. But now, when the Carousel at the last page, it continue to display from end to front. I think it goes against to meaning of infinite. Thus, I delete the code that will change direction  by autoPlayIterator in my project. In the code of I commit to slick, to be safe, I add an infiniteAutoplay configuration that if the value is true, it will change direction, if the value is false, Carousel will stop.