### PR TITLE
[BUGFIX] Navigation dots not navigating correctly

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -904,7 +904,11 @@
             if (_.options.centerMode === true) max = _.slideCount;
         } else {
             breakPoint = _.slideCount * -1;
-            counter = (_.slideCount * -1) -1;
+            if (((_.slideCount % 2) == 1) || ((_.options.slidesToScroll % 2) == 1)) {
+                counter = (_.slideCount * -1) -1;
+            } else {
+                counter = _.slideCount * -1;
+            }
             max = _.slideCount * 2;
         }
 

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -904,7 +904,6 @@
             if (_.options.centerMode === true) max = _.slideCount;
         } else {
             breakPoint = _.slideCount * -1;
-            var div = _.slideCount % _.options.slidesToScroll;
             if (((_.slideCount % _.options.slidesToScroll) > 0) && (((_.slideCount % 2) == 1) || ((_.options.slidesToScroll % 2) == 1))) {
                 counter = (_.slideCount * -1) -1;
             } else {

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -904,7 +904,7 @@
             if (_.options.centerMode === true) max = _.slideCount;
         } else {
             breakPoint = _.slideCount * -1;
-            counter = _.slideCount * -1;
+            counter = (_.slideCount * -1) -1;
             max = _.slideCount * 2;
         }
 

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -904,7 +904,8 @@
             if (_.options.centerMode === true) max = _.slideCount;
         } else {
             breakPoint = _.slideCount * -1;
-            if (((_.slideCount % 2) == 1) || ((_.options.slidesToScroll % 2) == 1)) {
+            var div = _.slideCount % _.options.slidesToScroll;
+            if (((_.slideCount % _.options.slidesToScroll) > 0) && (((_.slideCount % 2) == 1) || ((_.options.slidesToScroll % 2) == 1))) {
                 counter = (_.slideCount * -1) -1;
             } else {
                 counter = _.slideCount * -1;


### PR DESCRIPTION
Building off #1069 and #1039 there's an issue with the navigation dots with certain numbers of slides and `slidesToScroll`.

For example, if you have 14 slides and have `slidesToScroll`/`slidesToShow` set to 3, then start clicking the navigation dots, you'll generally be presented with the 3 previous slides (and missing 1 slide, usually the first.)  I have set up 2 fiddles, one that demonstrates the problem, and another fiddle that has the exact same HTML and JavaScript, just with my fixed version of Slick.

[JSFiddle that doesn't work correctly](http://jsfiddle.net/094obpe5/1/)
[JSFiddle that is fixed](http://jsfiddle.net/3pgksu48/6/)

This fix resolves the issue where either `slideCount` or `slidesToScroll` is odd, and `slidesToScroll` isn't a factor of `slideCount`.  Having said that, this can't resolve the issue of the offset of `slideCount` and `slidesToScroll` being greater than 1.

I hope I've described this issue correctly, and that you fix the patch appropriate.
