### PR TITLE
Page visibility fixes for 2 bugs.

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -682,9 +682,7 @@
 
         _.$list.off('click.slick', _.clickHandler);
 
-        if (_.options.autoplay === true) {
-            $(document).off(_.visibilityChange, _.visibility);
-        }
+        $(document).off(_.visibilityChange, _.visibility);
 
         _.$list.off('mouseenter.slick', _.setPaused.bind(_, true));
         _.$list.off('mouseleave.slick', _.setPaused.bind(_, false));
@@ -1094,9 +1092,7 @@
 
         _.$list.on('click.slick', _.clickHandler);
 
-        if (_.options.autoplay === true) {
-            $(document).on(_.visibilityChange, _.visibility.bind(_));
-        }
+        $(document).on(_.visibilityChange, _.visibility.bind(_));
 
         _.$list.on('mouseenter.slick', _.setPaused.bind(_, true));
         _.$list.on('mouseleave.slick', _.setPaused.bind(_, false));
@@ -2213,15 +2209,17 @@
     };
 
     Slick.prototype.visibility = function() {
-
+            
         var _ = this;
 
         if (document[_.hidden]) {
             _.paused = true;
             _.autoPlayClear();
         } else {
-            _.paused = false;
-            _.autoPlay();
+            if (_.options.autoplay === true) {
+                _.paused = false;
+                _.autoPlay();
+            }
         }
 
     };

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -165,9 +165,6 @@
             if (typeof document.mozHidden !== 'undefined') {
                 _.hidden = 'mozHidden';
                 _.visibilityChange = 'mozvisibilitychange';
-            } else if (typeof document.msHidden !== 'undefined') {
-                _.hidden = 'msHidden';
-                _.visibilityChange = 'msvisibilitychange';
             } else if (typeof document.webkitHidden !== 'undefined') {
                 _.hidden = 'webkitHidden';
                 _.visibilityChange = 'webkitvisibilitychange';


### PR DESCRIPTION
#927 - fixes this issue.

__Tested in IE10 and IE11.__
Bug was due to me blindly following an out-of-date Mozilla Dev guide: https://developer.mozilla.org/en-US/docs/Web/Guide/User_experience/Using_the_Page_Visibility_API where it incorrectly states "msvisibilitychange" as the event listener/handler for IE :disappointed: , after checking https://msdn.microsoft.com/library/ie/hh673553 it's clearly not the case. And tested, works as expected. :smile: 

=======

#1131 - fixes this issue.

Bug was due to `autoplay` being detected on load, but if the option was changed during the lifetime of the slider then the tab-switch never checked this and would carry on with whatever the initial value was at initialization. Now it will check the `autoplay` option every time the page changes visiblity.
http://jsfiddle.net/mphbk125/
