### PR TITLE
Add functionality for multiple slider syncing.

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -337,9 +337,12 @@
     };
 
     Slick.prototype.asNavFor = function(index) {
-        var _ = this,
-            asNavFor = _.options.asNavFor !== null ? $(_.options.asNavFor).slick('getSlick') : null;
-        if (asNavFor !== null) asNavFor.slideHandler(index, true);
+        var _ = this;
+        if (_.options.asNavFor !== null) {
+            $(_.options.asNavFor).each(function(i,element){
+                $(element).slick('getSlick').slideHandler(index, true);
+            });
+        }
     };
 
     Slick.prototype.applyTransition = function(slide) {


### PR DESCRIPTION
Add possibility to sync several sliders just setting as "asNavFor" parameter a list of jQuery selectors instead of just one.

This feature can be useful in case you want implement a gallery with thumbnails, caption and main image in different places of the HTML code all of them synced.

Example:
```html
<div class="slider slider-for">
    <div>image 1</div>
    <div>image 2</div>
</div>
<div class="slider slider-for-captions">
    <div>caption 1</div>
    <div>caption 2</div>
</div>
<div class="slider slider-nav">
    <div>thumb 1</div>
    <div>thumb 2</div>
</div>
```
```javascript
<script>
    $('.slider-for').slick({
        slidesToShow: 1,
        asNavFor: '.slider-for-captions, .slider-nav'
    });
    $('.slider-for-captions').slick({
        slidesToShow: 1,
        asNavFor: '.slider-nav, .slider-for'
    });
    $('.slider-nav').slick({
        slidesToShow: 3,
        asNavFor: '.slider-for-captions, .slider-for',
        focusOnSelect: true,
        slide: 'div'
    });
</script>
```