### PR TITLE
Updated README.md to reflect slickGoTo syntax

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -164,7 +164,7 @@ slickNext |  |  Triggers next slide
 slickPrev | | Triggers previous slide
 slickPause | | Pause Autoplay
 slickPlay | | Start Autoplay
-slickGoTo | index : int | Goes to slide by index
+slickGoTo | index : int, dontAnimate : bool | Goes to slide by index, skipping animation if second parameter is set to true
 slickCurrentSlide |  |  Returns the current slide index
 slickAdd | element : html or DOM object, index: int, addBefore: bool | Add a slide. If an index is provided, will add at that index, or before if addBefore is set. If no index is provided, add to the end or to the beginning if addBefore is set. Accepts HTML String || Object
 slickRemove | index: int, removeBefore: bool | Remove slide by index. If removeBefore is set true, remove slide preceding index, or the first slide if no index is specified. If removeBefore is set to false, remove the slide following index, or the last slide if no index is set.


### PR DESCRIPTION
The documentation was missing the second parameter for slickGoTo, added it in. Also, the marketing site has confusing documentation for that second parameter (I thought setting it to true would cause it to animate, not skip the animation). 

Thanks for the fantastic library!