### PR TITLE
goto jquery/DOM element, or selector string

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1010,8 +1010,22 @@
 
     Slick.prototype.goTo = Slick.prototype.slickGoTo = function(slide, dontAnimate) {
 
-        var _ = this;
-
+        var _ = this,
+            index, $slideCollection;
+        
+        if (typeof slide !== 'number'){
+            $slideCollection = _.$slideTrack
+                .children(this.options.slide)
+                .not(".slick-cloned");
+            
+            if (typeof slide === 'string')
+                slide = $(slide);
+            
+            index = $slideCollection.index(slide);
+        }else{
+            index = slide;
+        } 
+        
         _.changeSlide({
             data: {
                 message: 'index',

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1029,7 +1029,7 @@
         _.changeSlide({
             data: {
                 message: 'index',
-                index: parseInt(slide)
+                index: parseInt(index)
             }
         }, dontAnimate);
 


### PR DESCRIPTION
### Pass a jQuery Object, DOMElement or selector string to the slickGoTo function

```javascript
$slickElement.slick("slickGoTo", "#element-id");
```

[fiddle it out](http://jsfiddle.net/hxne3o6g/1/)