### PR TITLE
Bugfix #999 and #1079 (Unslick destroyed EventHandler)

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -757,7 +757,7 @@
                     width: ''
                 });
 
-            _.$slider.html(_.$slides);
+            _.$slider.prepend(_.$slides);
         }
 
         _.$slider.removeClass('slick-slider');


### PR DESCRIPTION
Replace .html() with .prepend() on destroy function, cause: When .html() is used to set an element's content, any content that was in that element is completely replaced by the new content. Additionally, jQuery removes other constructs such as data and event handlers from child elements before replacing those elements with the new content. [https://api.jquery.com/html/#html2](Find on jQuery API). Fixed Issue #999 and #1079.

[http://jsfiddle.net/webdesignberlin/ohnmp0yu/5/](original error) now [fixed](http://jsfiddle.net/webdesignberlin/ersybgam/1/)