### PR TITLE
Add namespaced events

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1090,7 +1090,7 @@
             _.updateDots();
         }
 
-        _.$slider.trigger('init', [_]);
+        _.$slider.trigger('init', [_]).trigger('init.slick', [_]);
 
     };
 
@@ -1346,7 +1346,7 @@
 
         var _ = this;
 
-        _.$slider.trigger('afterChange', [_, index]);
+        _.$slider.trigger('afterChange', [_, index]).trigger('afterChange.slick', [_, index]);
 
         _.animating = false;
 
@@ -1462,7 +1462,7 @@
 
         _.setPosition();
 
-        _.$slider.trigger('reInit', [_]);
+        _.$slider.trigger('reInit', [_]).trigger('reInit.slick', [_]);
 
     };
 
@@ -1653,7 +1653,7 @@
             _.setFade();
         }
 
-        _.$slider.trigger('setPosition', [_]);
+        _.$slider.trigger('setPosition', [_]).trigger('setPosition.slick', [_]);
 
     };
 
@@ -1924,7 +1924,7 @@
 
         _.animating = true;
 
-        _.$slider.trigger("beforeChange", [_, _.currentSlide, animSlide]);
+        _.$slider.trigger("beforeChange", [_, _.currentSlide, animSlide]).trigger("beforeChange.slick", [_, _.currentSlide, animSlide]);
 
         oldSlide = _.currentSlide;
         _.currentSlide = animSlide;
@@ -2025,7 +2025,7 @@
         }
 
         if (_.touchObject.edgeHit === true) {
-            _.$slider.trigger("edge", [_, _.swipeDirection()]);
+            _.$slider.trigger("edge", [_, _.swipeDirection()]).trigger("edge.slick", [_, _.swipeDirection()]);
         }
 
         if (_.touchObject.swipeLength >= _.touchObject.minSwipe) {
@@ -2036,7 +2036,7 @@
                     _.slideHandler(slideCount);
                     _.currentDirection = 0;
                     _.touchObject = {};
-                    _.$slider.trigger("swipe", [_, "left"]);
+                    _.$slider.trigger("swipe", [_, "left"]).trigger("swipe.slick", [_, "left"]);
                     break;
 
                 case 'right':
@@ -2044,7 +2044,7 @@
                     _.slideHandler(slideCount);
                     _.currentDirection = 1;
                     _.touchObject = {};
-                    _.$slider.trigger("swipe", [_, "right"]);
+                    _.$slider.trigger("swipe", [_, "right"]).trigger("swipe.slick", [_, "right"]);
                     break;
             }
         } else {


### PR DESCRIPTION
This adds additional namespaced events for the ability to reduce conflicts when working with multiple plugins

Orig: ```_.$slider.trigger('init', [_])```
New: ```_.$slider.trigger('init', [_]).trigger('init.slick', [_]);```

Didn't remove original trigger so this change is non-breaking.