### PR TITLE
Fix for last dot not working in some cases in infinite mode

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1006,7 +1006,7 @@
             max;
 
         if (_.options.infinite === false) {
-            max = _.slideCount - _.options.slidesToShow + 1;
+            max = Math.ceil(_.slideCount / _.options.slidesToShow) * _.options.slidesToShow;
             if (_.options.centerMode === true) max = _.slideCount;
         } else {
             breakPoint = _.options.slidesToScroll * -1;


### PR DESCRIPTION
More details are in #1088.

For the test cases, clicking the second dot is how I've been testing.

Before: http://jsfiddle.net/spgx6nzh/
After: http://jsfiddle.net/maad9poa/3/

I'd be happy to expand the fiddles to include more scenarios but might need a bit of guidance.