### PR TITLE
Fixes issue with customPaging children click event

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -661,7 +661,7 @@
 
             case 'index':
                 var index = event.data.index === 0 ? 0 :
-                    event.data.index || $(event.target).parent().index() * _.options.slidesToScroll;
+                    event.data.index || $(event.target).parents('li').index() * _.options.slidesToScroll;
 
                 _.slideHandler(_.checkNavigable(index), false, dontAnimate);
                 break;


### PR DESCRIPTION
Test case fiddle: http://jsfiddle.net/jamie3d/tah9tndm/1/

Not that clicking the "Foo" text (appended directly) works as expected. Clicking any of the other child elements fails to fire due to the indicated change.

Similar to #1204 and #293 