### PR TITLE
Fixing reverse swiping with infinite scroll.

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1010,8 +1010,8 @@
             max = _.slideCount - _.options.slidesToShow + 1;
             if (_.options.centerMode === true) max = _.slideCount;
         } else {
-            breakPoint = _.options.slidesToScroll * -1;
-            counter = _.options.slidesToScroll * -1;
+            breakPoint = (_.slideCount * -1) + 1;
+            counter = (_.slideCount * -1) + 1;
             max = _.slideCount * 2;
         }
 


### PR DESCRIPTION
This fixes a problem where enabling swipeToSlide with infinite option and slidesToShow > 1 does not let you swipe from right to left, only from left to right.

Test case without the fix: http://jsfiddle.net/mkLug0of/

Test case after the fix: http://jsfiddle.net/k0yadLLy/1/

Behavior with infinite turned off hasn't been changed.