### PR TITLE
Add 'destroy' event to slick

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -819,6 +819,8 @@
         _.$slider.removeClass('slick-slider');
         _.$slider.removeClass('slick-initialized');
 
+        _.$slider.trigger('destroy', [_]);
+
     };
 
     Slick.prototype.disableTransition = function(slide) {


### PR DESCRIPTION
This is quite useful. One of the use case is that I use Init to remove several class that affect dom of Slick. After unslick it should be added back to the dom. 