### PR TITLE
Fix getNavigableIndexes when infinite and centerMode are false

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1016,12 +1016,9 @@
             breakPoint = 0,
             counter = 0,
             indexes = [],
-            max;
+            max = _.slideCount;
 
-        if (_.options.infinite === false) {
-            max = _.slideCount - _.options.slidesToShow + 1;
-            if (_.options.centerMode === true) max = _.slideCount;
-        } else {
+        if (_.options.infinite === true) {
             breakPoint = _.options.slidesToScroll * -1;
             counter = _.options.slidesToScroll * -1;
             max = _.slideCount * 2;


### PR DESCRIPTION
Fix for https://github.com/kenwheeler/slick/issues/1285

JSFiddle to reproduce the issue: http://jsfiddle.net/f262t1ov/
