### PR TITLE
Bugfix 1250

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -674,6 +674,7 @@
                     event.data.index || $target.index() * _.options.slidesToScroll;
 
                 _.slideHandler(_.checkNavigable(index), false, dontAnimate);
+                $target.children().trigger("focus");
                 break;
 
             default:

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -641,7 +641,14 @@
             indexOffset, slideOffset, unevenOffset;
 
         // If target is a link, prevent default action.
-        $target.is('a') && event.preventDefault();
+        if($target.is('a')) {
+            event.preventDefault();
+        }
+
+        // If target is not the <li> element (ie: a child), find the <li>.
+        if(!$target.is('li')) { 
+            $target = $target.closest('li');
+        }
 
         unevenOffset = (_.slideCount % _.options.slidesToScroll !== 0);
         indexOffset = unevenOffset ? 0 : (_.slideCount - _.currentSlide) % _.options.slidesToScroll;
@@ -664,7 +671,7 @@
 
             case 'index':
                 var index = event.data.index === 0 ? 0 :
-                    event.data.index || $(event.target).parent().index() * _.options.slidesToScroll;
+                    event.data.index || $target.index() * _.options.slidesToScroll;
 
                 _.slideHandler(_.checkNavigable(index), false, dontAnimate);
                 break;


### PR DESCRIPTION
Fixes Issue #1250 
http://jsfiddle.net/xs87r5La/1/

---

Previously the `event.target` could possibly be the `<li>` tag if the CSS was changed; which would then expose the index of the `<ul>` instead of the `<li>` causing the slider to go to the wrong slide index.