### PR TITLE
use jQuery css function instead of width

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -549,8 +549,10 @@
             };
             _.$slider.html(newSlides);
             _.$slider.children().children().children()
-                .css('width', (100 / _.options.slidesPerRow) + "%")
-                .css({'display': 'inline-block'});
+                .css({
+                    'width':(100 / _.options.slidesPerRow) + "%",
+                    'display': 'inline-block'
+                });
         };
 
     };

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -549,7 +549,7 @@
             };
             _.$slider.html(newSlides);
             _.$slider.children().children().children()
-                .width((100 / _.options.slidesPerRow) + "%")
+                .css('width', (100 / _.options.slidesPerRow) + "%")
                 .css({'display': 'inline-block'});
         };
 


### PR DESCRIPTION
Broken: http://codepen.io/ethanclevenger91/pen/MwwoqJ
Fixed: http://codepen.io/ethanclevenger91/pen/EjjXdb

Could honestly be a jQuery thing, but in the `buildRows` function:

`.width((100 / _.options.slidesPerRow) + "%")`

adds padding to the value written. `(100 / _.options.slidesPerRow) + '%'` may result in `33.33...%`, but if you have `padding:5px`, you can log right after that line the value and see that it's been set to `43.33...%` - 10% is added (twice the padding as a percentage). Swapping that line for:

`.css('width', (100 / _.options.slidesPerRow) + "%")` resolves the issue.

Didn't see build instruction - let me know if I need to take care of that