### PR TITLE
AsNavFor, Breakpoint and Init Events.

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -645,6 +645,7 @@
                 }
             }
 
+            // only trigger breakpoints during an actual break. not on initialize.
             if( !initial && triggerBreakpoint !== false ) {
                 _.$slider.trigger('breakpoint', [_, triggerBreakpoint]);
             }

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -191,7 +191,7 @@
             // Extracted from jQuery v1.11 source
             _.htmlExpr = /^(?:\s*(<[\w\W]+>)[^>]*)$/;
 
-            _.init();
+            _.init(true);
 
             _.checkResponsive(true);
 
@@ -1108,7 +1108,7 @@
 
     };
 
-    Slick.prototype.init = function() {
+    Slick.prototype.init = function(creation) {
 
         var _ = this;
 
@@ -1125,7 +1125,9 @@
             _.updateDots();
         }
 
-        _.$slider.trigger('init', [_]);
+        if (creation) {
+            _.$slider.trigger('init', [_]);
+        }
 
     };
 

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -605,13 +605,14 @@
                         _.activeBreakpoint =
                             targetBreakpoint;
                         if (_.breakpointSettings[targetBreakpoint] === 'unslick') {
-                            _.unslick();
+                            _.unslick(targetBreakpoint);
                         } else {
                             _.options = $.extend({}, _.originalSettings,
                                 _.breakpointSettings[
                                     targetBreakpoint]);
-                            if (initial === true)
+                            if (initial === true) {
                                 _.currentSlide = _.options.initialSlide;
+                            }
                             _.refresh();
                         }
                         _.$slider.trigger('breakpoint', [_, targetBreakpoint]);
@@ -619,13 +620,14 @@
                 } else {
                     _.activeBreakpoint = targetBreakpoint;
                     if (_.breakpointSettings[targetBreakpoint] === 'unslick') {
-                        _.unslick();
+                        _.unslick(targetBreakpoint);
                     } else {
                         _.options = $.extend({}, _.originalSettings,
                             _.breakpointSettings[
                                 targetBreakpoint]);
-                        if (initial === true)
+                        if (initial === true) {
                             _.currentSlide = _.options.initialSlide;
+                        }
                         _.refresh();
                     }
                     _.$slider.trigger('breakpoint', [_, targetBreakpoint]);
@@ -634,8 +636,9 @@
                 if (_.activeBreakpoint !== null) {
                     _.activeBreakpoint = null;
                     _.options = _.originalSettings;
-                    if (initial === true)
+                    if (initial === true) {
                         _.currentSlide = _.options.initialSlide;
+                    }
                     _.refresh();
                     _.$slider.trigger('breakpoint', [_, targetBreakpoint]);
                 }
@@ -2255,9 +2258,10 @@
 
     };
 
-    Slick.prototype.unslick = function() {
+    Slick.prototype.unslick = function( fromBreakpoint ) {
 
         var _ = this;
+        _.$slider.trigger('unslick', [_, fromBreakpoint]);
         _.destroy();
 
     };

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2265,7 +2265,7 @@
 
     };
 
-    Slick.prototype.unslick = function( fromBreakpoint ) {
+    Slick.prototype.unslick = function(fromBreakpoint) {
 
         var _ = this;
         _.$slider.trigger('unslick', [_, fromBreakpoint]);

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -342,7 +342,7 @@
             asNavFor = _.options.asNavFor;
 
         if ( asNavFor && asNavFor !== null ) {
-            asNavFor = $(asNavFor);
+            asNavFor = $(asNavFor).not(_.$slider);
         }
 
         if ( asNavFor !== null && typeof asNavFor === "object" ) {

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -569,9 +569,10 @@
     Slick.prototype.checkResponsive = function(initial) {
 
         var _ = this,
-            breakpoint, targetBreakpoint, respondToWidth;
+            breakpoint, targetBreakpoint, respondToWidth, triggerBreakpoint = false;
         var sliderWidth = _.$slider.width();
         var windowWidth = window.innerWidth || $(window).width();
+
         if (_.respondTo === 'window') {
             respondToWidth = windowWidth;
         } else if (_.respondTo === 'slider') {
@@ -615,7 +616,7 @@
                             }
                             _.refresh();
                         }
-                        _.$slider.trigger('breakpoint', [_, targetBreakpoint]);
+                        triggerBreakpoint = targetBreakpoint;
                     }
                 } else {
                     _.activeBreakpoint = targetBreakpoint;
@@ -630,7 +631,7 @@
                         }
                         _.refresh();
                     }
-                    _.$slider.trigger('breakpoint', [_, targetBreakpoint]);
+                    triggerBreakpoint = targetBreakpoint;
                 }
             } else {
                 if (_.activeBreakpoint !== null) {
@@ -640,10 +641,13 @@
                         _.currentSlide = _.options.initialSlide;
                     }
                     _.refresh();
-                    _.$slider.trigger('breakpoint', [_, targetBreakpoint]);
+                    triggerBreakpoint = targetBreakpoint;
                 }
             }
 
+            if( !initial && triggerBreakpoint !== false ) {
+                _.$slider.trigger('breakpoint', [_, triggerBreakpoint]);
+            }
         }
 
     };


### PR DESCRIPTION
___JSFiddle: http://jsfiddle.net/0u5qyg8x/___

- Merge in and amend @limonte asNavFor patch - allowing use of `$()` objects as targets.
- Fix up a small bug in @limonte patch as it was incorrectly type-checking for `null`
- Add the ability to `asNavFor` on mulitple slick instances.
- Fix up `breakpoint` events so they only fire during `resize` and not on `init`
- Fix up `init` event so it doesn't fire on `resize` anymore.
- Add `unslick` event which will also expose the breakpoint at which it unslicked (if possible).  
- Take cue from @muddylemon [branch](https://github.com/muddylemon/slick/commit/6e44c4f9b1b6df214a27672074d35b33b7c3d42e#diff-eaaa72f2e5f1d4974e4f1ae902717908R340) to prevent using `self` as `asNavFor` target.

===
- closes #865
- closes #1298 
- closes #1150 

===
[This patch's jsfiddle](http://jsfiddle.net/0u5qyg8x) also neatly demonstrates some of the bugs in `Slick.prototype.slideHandler()` regarding non-infinite-carousels as targets from infinite-carousels (wrong index is passed). I had a crack at that, too... but it's pretty damn crazy up in that method! So left it alone for now.