### PR TITLE
check if the asNavFor target has been unslicked, or not.

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -347,7 +347,10 @@
 
         if ( asNavFor !== null && typeof asNavFor === "object" ) {
             asNavFor.each(function() {
-                $(this).slick('getSlick').slideHandler(index, true);
+                var target = $(this).slick('getSlick');
+                if(!target.options.unslicked) {
+                    target.slideHandler(index, true);
+                }
             });
         }
 
@@ -845,6 +848,8 @@
 
         _.$slider.removeClass('slick-slider');
         _.$slider.removeClass('slick-initialized');
+
+        _.options.unslicked = true;
 
     };
 

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -348,7 +348,7 @@
         if ( asNavFor !== null && typeof asNavFor === "object" ) {
             asNavFor.each(function() {
                 var target = $(this).slick('getSlick');
-                if(!target.options.unslicked) {
+                if(!target.unslicked) {
                     target.slideHandler(index, true);
                 }
             });
@@ -849,7 +849,7 @@
         _.$slider.removeClass('slick-slider');
         _.$slider.removeClass('slick-initialized');
 
-        _.options.unslicked = true;
+        _.unslicked = true;
 
     };
 


### PR DESCRIPTION
Resolves #1304 

- __Before:__ http://jsfiddle.net/odoqefdq/
_(notice the unslicked carousel will get `.slick-active` and `aria-hidden=false` applied to it.)_

- __After:__ http://jsfiddle.net/odoqefdq/1/
_(now the unslicked carousel will not get attributes added, because `asNavFor()` doesn't run on it.)_

===

@kenwheeler could you review this one, please, because I added a kind-of architecture piece to it on line 852, regarding a `unslicked` state after a carousel has been destroyed. I couldn't see a valid and efficient way to check for an "_unslicked_" carousel in the exisiting code. :confounded:  -- You might have a better/different thought on how to do this. :smile: 