### PR TITLE
Bugfix 1311

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -111,7 +111,8 @@
                 swipeLeft: null,
                 $list: null,
                 touchObject: {},
-                transformsEnabled: false
+                transformsEnabled: false,
+                unslicked: false
             };
 
             $.extend(_, _.initials);

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -631,8 +631,9 @@
                                 targetBreakpoint]);
                         if (initial === true) {
                             _.currentSlide = _.options.initialSlide;
+                        } else {
+                            _.refresh();
                         }
-                        _.refresh();
                     }
                     triggerBreakpoint = targetBreakpoint;
                 }


### PR DESCRIPTION
- Fixes #1311 (https://github.com/simeydotme/slick/commit/0d4339d5ad3ff25ad85863d8f548775b17ee9162)
- Patches https://github.com/simeydotme/slick/commit/bc53ab98ececb0751157fc2c3ed887dd9f5ea737

====
There was an oversight not adding `_.unslicked` to the `_.initials` object, meaning carousels could lose synchrony between breakpoints. - Sorry, Bro! :disappointed: 