### PR TITLE
Enhancement: Restore any inline styling from before slick init.

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -494,7 +494,9 @@
         _.slideCount = _.$slides.length;
 
         _.$slides.each(function(index, element) {
-            $(element).attr('data-slick-index', index);
+            $(element)
+                .attr('data-slick-index', index)
+                .data('originalStyling', $(element).attr('style') || '');
         });
 
         _.$slidesCache = _.$slides;
@@ -828,16 +830,13 @@
         }
 
         if (_.$slides) {
-            _.$slides.removeClass('slick-slide slick-active slick-center slick-visible')
+
+            _.$slides
+                .removeClass('slick-slide slick-active slick-center slick-visible')
                 .removeAttr('aria-hidden')
                 .removeAttr('data-slick-index')
-                .css({
-                    position: '',
-                    left: '',
-                    top: '',
-                    zIndex: '',
-                    opacity: '',
-                    width: ''
+                .each(function(){
+                    $(this).attr('style', $(this).data('originalStyling'));
                 });
 
             _.$slideTrack.children(this.options.slide).detach();


### PR DESCRIPTION
If the `slick-slides` had, for some inexplicable reason, a styling-attribute and the css in that attribute was one of the styles that slick modifies, then after `destroy`/`unslick`; those styles would be lost. 

This enhancement stores the original styling as a `data-attribute` on `init()` and reapplies it upon `destroy()`. :fist:  -- barely necessary, I know... but?

[JSFiddle __without__ enchancement](http://jsfiddle.net/u3do680a/2/)
[JSFiddle __with__ enchancement](http://jsfiddle.net/u3do680a/3/)

_This was tested in IE8+, FF33+ and Chrome (edge)_ :cold_sweat: