### PR TITLE
Enhancement 1244 - Slick Arrows States

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -440,21 +440,33 @@
 
         var _ = this;
 
-        if (_.options.arrows === true && _.slideCount > _.options.slidesToShow) {
+        if (_.options.arrows === true ) {
 
-            _.$prevArrow = $(_.options.prevArrow);
-            _.$nextArrow = $(_.options.nextArrow);
+            _.$prevArrow = $(_.options.prevArrow).addClass('slick-arrow');
+            _.$nextArrow = $(_.options.nextArrow).addClass('slick-arrow');
+            
+            if( _.slideCount > _.options.slidesToShow ) {
 
-            if (_.htmlExpr.test(_.options.prevArrow)) {
-                _.$prevArrow.appendTo(_.options.appendArrows);
-            }
+                _.$prevArrow.removeClass('slick-hidden');
+                _.$nextArrow.removeClass('slick-hidden');
 
-            if (_.htmlExpr.test(_.options.nextArrow)) {
-                _.$nextArrow.appendTo(_.options.appendArrows);
-            }
+                if (_.htmlExpr.test(_.options.prevArrow)) {
+                    _.$prevArrow.appendTo(_.options.appendArrows);
+                }
 
-            if (_.options.infinite !== true) {
-                _.$prevArrow.addClass('slick-disabled');
+                if (_.htmlExpr.test(_.options.nextArrow)) {
+                    _.$nextArrow.appendTo(_.options.appendArrows);
+                }
+
+                if (_.options.infinite !== true) {
+                    _.$prevArrow.addClass('slick-disabled');
+                }
+
+            } else {
+
+                _.$prevArrow.addClass('slick-hidden');
+                _.$nextArrow.addClass('slick-hidden');
+
             }
 
         }
@@ -828,11 +840,19 @@
         if (_.$dots) {
             _.$dots.remove();
         }
-        if (_.$prevArrow && (typeof _.options.prevArrow !== 'object')) {
-            _.$prevArrow.remove();
+
+        if ( _.$prevArrow.length ) {
+            _.$prevArrow.removeClass('slick-disabled slick-arrow slick-hidden').css("display","");
+            if ( _.htmlExpr.test( _.options.prevArrow )) {
+                _.$prevArrow.remove();
+            }
         }
-        if (_.$nextArrow && (typeof _.options.nextArrow !== 'object')) {
-            _.$nextArrow.remove();
+
+        if ( _.$nextArrow.length ) {
+            _.$nextArrow.removeClass('slick-disabled slick-arrow slick-hidden').css("display","");
+            if ( _.htmlExpr.test( _.options.nextArrow )) {
+                _.$nextArrow.remove();
+            }
         }
 
         if (_.$slides) {
@@ -2400,10 +2420,13 @@
 
         centerOffset = Math.floor(_.options.slidesToShow / 2);
 
-        if (_.options.arrows === true && _.options.infinite !==
-            true && _.slideCount > _.options.slidesToShow) {
+        if ( _.options.arrows === true && 
+            _.slideCount > _.options.slidesToShow && 
+            !_.options.infinite ) {
+
             _.$prevArrow.removeClass('slick-disabled');
             _.$nextArrow.removeClass('slick-disabled');
+
             if (_.currentSlide === 0) {
                 _.$prevArrow.addClass('slick-disabled');
                 _.$nextArrow.removeClass('slick-disabled');
@@ -2414,6 +2437,7 @@
                 _.$nextArrow.addClass('slick-disabled');
                 _.$prevArrow.removeClass('slick-disabled');
             }
+
         }
 
     };

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2390,11 +2390,11 @@
             _.$dots.remove();
         }
 
-        if (_.$prevArrow && (typeof _.options.prevArrow !== 'object')) {
+        if (_.$prevArrow && _.htmlExpr.test(_.options.prevArrow)) {
             _.$prevArrow.remove();
         }
 
-        if (_.$nextArrow && (typeof _.options.nextArrow !== 'object')) {
+        if (_.$nextArrow && _.htmlExpr.test(_.options.nextArrow)) {
             _.$nextArrow.remove();
         }
 

--- a/slick/slick.scss
+++ b/slick/slick.scss
@@ -94,3 +94,6 @@
         border: 1px solid transparent;
     }
 }
+.slick-arrow.slick-hidden {
+    display: none;
+}


### PR DESCRIPTION
Yo, @kenwheeler , @herrschuessler :man: - please have a quick look over this commit, and this jsfiddle http://jsfiddle.net/simeydotme/qdgwc3gp/ to demonstrate the fix :) - should fix #1244 by adding some state classes for the arrows (when the arrows are dom objects) ... 

the .scss change, though, seems like it could cause trouble for people, so we can discuss to leave it out, or bump to 1.6.0 ? - There's been a lot of fixes in the last couple of weeks, so it might not be a bad idea.

- fixes #907
- fixes #1244

Si.