### PR TITLE
changing zIndex magic-number in fadeSlilde() and setFade() to a user-declared option variable

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -85,7 +85,8 @@
                 variableWidth: false,
                 vertical: false,
                 verticalSwiping: false,
-                waitForAnimate: true
+                waitForAnimate: true,
+                zIndex: 1000
             };
 
             _.initials = {
@@ -164,6 +165,10 @@
                         return b - a;
                     }
                 });
+            }
+
+            if (_.options.zIndex < 3) {
+                _.options.zIndex = 3;
             }
 
             if (typeof document.mozHidden !== 'undefined') {
@@ -885,7 +890,7 @@
         if (_.cssTransitions === false) {
 
             _.$slides.eq(slideIndex).css({
-                zIndex: 1000
+                zIndex: _.options.zIndex
             });
 
             _.$slides.eq(slideIndex).animate({
@@ -898,7 +903,7 @@
 
             _.$slides.eq(slideIndex).css({
                 opacity: 1,
-                zIndex: 1000
+                zIndex: _.options.zIndex
             });
 
             if (callback) {
@@ -1648,7 +1653,7 @@
                     position: 'relative',
                     right: targetLeft,
                     top: 0,
-                    zIndex: 800,
+                    zIndex: _.options.zIndex - 2,
                     opacity: 0
                 });
             } else {
@@ -1656,14 +1661,14 @@
                     position: 'relative',
                     left: targetLeft,
                     top: 0,
-                    zIndex: 800,
+                    zIndex: _.options.zIndex - 2,
                     opacity: 0
                 });
             }
         });
 
         _.$slides.eq(_.currentSlide).css({
-            zIndex: 900,
+            zIndex: _.options.zIndex - 1,
             opacity: 1
         });
 


### PR DESCRIPTION
PROMPT: our site has a drop down menu whose z-index was being trumped
when we had Slick fade set to true. Rather than adjust and have to
regression test our component, I wanted Slick to be flexible enough to
accommodate pre-existing components’ z-indexes when it’s being
integrated later in a project.

CHANGES: zIndex for currentSlide was being set to “1000”. I added
zIndex to the set of author-able options and set it to 1000 by default.

The extra level of control is non-invasive as the current zIndex
settings are relative to one another. Since none of the other Slick
elements have z-indexing authors couldn’t break Slick itself.

I changed the differences to be single instead of by hundreds since a
user could potentially submit a single-digit zIndex.

Since the setFade() zIndex has to drop by 2, there is a check at the
beginning to make sure the zIndex can never go to 0 or -1 by setting it
to at least 3.

PAIN-POINT: I didn’t put in a check to see if z-index was defined as a
valid number, but I’m not seeing where any other variable is validated
so that seemed okay.