### PR TITLE
Fixing #1353 by filtering the slides in buildOut()

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -489,9 +489,11 @@
 
         var _ = this;
 
-        _.$slides = _.$slider.children(
-            ':not(.slick-cloned)').addClass(
-            'slick-slide');
+        _.$slides = 
+            _.$slider
+                .children( _.options.slide + ':not(.slick-cloned)')
+                .addClass('slick-slide');
+
         _.slideCount = _.$slides.length;
 
         _.$slides.each(function(index, element) {


### PR DESCRIPTION
This filter was removed at
https://github.com/kenwheeler/slick/commit/9d13d6abc4ab4e05948b5bab47b2574fad9c9c64#diff-eaaa72f2e5f1d4974e4f1ae902717908L476
for some reason, I cannot figure out why. Since it was removed, filtering
slides was not working on initialization.

Tested against Init.
Tested against setOption.
Tested against breakpoints.

Fixes #1353