### PR TITLE
Fixes #1354 - Race condition on Cloned Lazy Load

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1307,24 +1307,26 @@
 
         function loadImages(imagesScope) {
             $('img[data-lazy]', imagesScope).each(function() {
+
                 var image = $(this),
                     imageSource = $(this).attr('data-lazy'),
                     imageToLoad = document.createElement('img');
 
                 imageToLoad.onload = function() {
-                    image.animate({
-                        opacity: 1
-                    }, 200);
+                    image
+                        .animate({ opacity: 0 }, 100, function() {
+                            image
+                                .attr('src', imageSource)
+                                .animate({ opacity: 1 }, 200, function() {
+                                    image
+                                        .removeAttr('data-lazy')
+                                        .removeClass('slick-loading');
+                                });
+                        });
                 };
+
                 imageToLoad.src = imageSource;
 
-                image
-                    .css({
-                        opacity: 0
-                    })
-                    .attr('src', imageSource)
-                    .removeAttr('data-lazy')
-                    .removeClass('slick-loading');
             });
         }
 


### PR DESCRIPTION
In some scenarios (one being `slidesToShow: 2`, `slidesToScroll: 1`) the
cloned slide would have it's `data-lazy` removed, but not actually animate
it's `opacity` to `1`, leaving an invisible image inside the cloned slide.

I narrowed it down to the order of code inside the `onload()` function, and
the code outside of the `onload()` function. Fixed it by making the loading,
animation and attribute settings synchronous using callbacks from
the `.animate()` functions.

The setting of `opacity: 0;` now also has a very fast animation, which makes
the loading of images seem less jarring.