### PR TITLE
Prevent double-binding the click event

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1180,14 +1180,16 @@
         var _ = this;
 
         if (_.options.arrows === true && _.slideCount > _.options.slidesToShow) {
-            _.$prevArrow.off('click.slick');
-            _.$prevArrow.on('click.slick', {
-                message: 'previous'
-            }, _.changeSlide);
-            _.$nextArrow.off('click.slick');
-            _.$nextArrow.on('click.slick', {
-                message: 'next'
-            }, _.changeSlide);
+            _.$prevArrow
+               .off('click.slick')
+               .on('click.slick', {
+                    message: 'previous'
+               }, _.changeSlide);
+            _.$nextArrow
+               .off('click.slick')
+               .on('click.slick', {
+                    message: 'next'
+               }, _.changeSlide);
         }
 
     };

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1180,9 +1180,11 @@
         var _ = this;
 
         if (_.options.arrows === true && _.slideCount > _.options.slidesToShow) {
+            _.$prevArrow.off('click.slick');
             _.$prevArrow.on('click.slick', {
                 message: 'previous'
             }, _.changeSlide);
+            _.$nextArrow.off('click.slick');
             _.$nextArrow.on('click.slick', {
                 message: 'next'
             }, _.changeSlide);


### PR DESCRIPTION
Prevent double-binding the click event to the next/prev arrows. This scenario happens when you use the removeSlide method.