### PR TITLE
wrong extend order in refresh function

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1489,7 +1489,7 @@
 
         _.destroy(true);
 
-        $.extend(_.initials, _);
+        $.extend(_, _.initials, { currentSlide: currentSlide });
 
         _.init();
 

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1489,7 +1489,7 @@
 
         _.destroy(true);
 
-        $.extend(_, _.initials);
+        $.extend(_.initials, _);
 
         _.init();
 


### PR DESCRIPTION
refresh function: wrong extend order for current settings _ and _.initials.

this will break settings like initialSlide in combination with responsive.
in this case the initialSlide property will be overwritten by _.initials.initialSlide which is always 0.