### PR TITLE
Make sure slick-active is currentSlide after reinit()

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1545,7 +1545,7 @@
             $(_.$slideTrack).children().on('click.slick', _.selectHandler);
         }
 
-        _.setSlideClasses(0);
+        _.setSlideClasses(typeof _.currentSlide === 'number' ? _.currentSlide : 0);
 
         _.setPosition();
 


### PR DESCRIPTION
Fixes https://github.com/kenwheeler/slick/issues/1421

>##### Steps to Reproduce:
>1. Go to JSBin http://jsbin.com/mademegize/3/edit?html,js,output
>2. Click Next
>
>##### Expected Results: 
>* .slick-active stays .slick-active
>
>##### Actual Results:
>* Green (.slick-active) turns red (.slick)
>
>##### What caused this:
>* New slide was added when currentSlide != 0