### PR TITLE
Pass dontAnimate through to asNavFor

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -338,7 +338,7 @@
 
     };
 
-    Slick.prototype.asNavFor = function(index) {
+    Slick.prototype.asNavFor = function(index, dontAnimate) {
 
         var _ = this,
             asNavFor = _.options.asNavFor;
@@ -351,7 +351,7 @@
             asNavFor.each(function() {
                 var target = $(this).slick('getSlick');
                 if(!target.unslicked) {
-                    target.slideHandler(index, true);
+                    target.slideHandler(index, true, dontAnimate);
                 }
             });
         }
@@ -2015,7 +2015,7 @@
         }
 
         if (sync === false) {
-            _.asNavFor(index);
+            _.asNavFor(index, dontAnimate);
         }
 
         targetSlide = index;


### PR DESCRIPTION
Is it possible for dontAnimate to be passed into the NAV as I don't wont either of them to animate (for this one time only).
I've tried doing it like this:
```
$('.slick').slick('slickGoTo', 1, true);
$('.slick-nav').slick('slickGoTo', 1, true);
```
Because the animation is already under way from the the first call it doesn't take effect.

Thanks.