### PR TITLE
Bugfix for issue 1059

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1035,11 +1035,15 @@
         }
 
         if (_.options.centerMode === true && _.options.infinite === true) {
-            _.slideOffset += _.slideWidth * Math.floor(_.options.slidesToShow / 2) - _.slideWidth;
-        } else if (_.options.centerMode === true) {
-            _.slideOffset = 0;
-            _.slideOffset += _.slideWidth * Math.floor(_.options.slidesToShow / 2);
-        }
+			if (_.slideCount <= _.options.slidesToShow) {
+				_.slideOffset = ((_.slideWidth * Math.floor(_.options.slidesToShow)) / 2) - ((_.slideWidth * _.slideCount) / 2);
+			} else {
+				_.slideOffset += _.slideWidth * Math.floor(_.options.slidesToShow / 2) - _.slideWidth;
+			}
+		} else if (_.options.centerMode === true) {
+			_.slideOffset = 0;
+			_.slideOffset += _.slideWidth * Math.floor(_.options.slidesToShow / 2);
+		}
 
         if (_.options.vertical === false) {
             targetLeft = ((slideIndex * _.slideWidth) * -1) + _.slideOffset;


### PR DESCRIPTION
Issue #1059 raised an offset calculation issue for sliders with `centreMode: true`, and an `itemCount` that was less than or equal to `slidesToShow`.

Needing a fix for this for the project I was working on made me want to explore the code and find a fix, that can be found in the PR.