### PR TITLE
Fixing handling negative value for 'slidesToScroll' - changing direction

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "slick-carousel",
     "main": ["slick/slick.min.js", "slick/slick.css", "slick/slick-theme.css", "slick/fonts/*"],
-    "version": "1.5.8",
+    "version": "1.5.9",
     "homepage": "https://github.com/kenwheeler/slick",
     "authors": [
         "Ken Wheeler <ken_wheeler@me.com>"

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "slick-carousel",
     "main": ["slick/slick.min.js", "slick/slick.css", "slick/slick-theme.css", "slick/fonts/*"],
-    "version": "1.5.11",
+    "version": "1.5.12",
     "homepage": "https://github.com/kenwheeler/slick",
     "authors": [
         "Ken Wheeler <ken_wheeler@me.com>"

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "slick-carousel",
     "main": ["slick/slick.min.js", "slick/slick.css", "slick/slick-theme.css", "slick/fonts/*"],
-    "version": "1.5.13",
+    "version": "1.5.14",
     "homepage": "https://github.com/kenwheeler/slick",
     "authors": [
         "Ken Wheeler <ken_wheeler@me.com>"

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "slick-carousel",
     "main": ["slick/slick.min.js", "slick/slick.css", "slick/slick-theme.css", "slick/fonts/*"],
-    "version": "1.5.9",
+    "version": "1.5.10",
     "homepage": "https://github.com/kenwheeler/slick",
     "authors": [
         "Ken Wheeler <ken_wheeler@me.com>"

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "slick-carousel",
     "main": ["slick/slick.min.js", "slick/slick.css", "slick/slick-theme.css", "slick/fonts/*"],
-    "version": "1.5.10",
+    "version": "1.5.11",
     "homepage": "https://github.com/kenwheeler/slick",
     "authors": [
         "Ken Wheeler <ken_wheeler@me.com>"

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "slick-carousel",
     "main": ["slick/slick.min.js", "slick/slick.css", "slick/slick-theme.css", "slick/fonts/*"],
-    "version": "1.5.12",
+    "version": "1.5.13",
     "homepage": "https://github.com/kenwheeler/slick",
     "authors": [
         "Ken Wheeler <ken_wheeler@me.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "slick-carousel",
-    "version": "1.5.10",
+    "version": "1.5.11",
     "description": "the last carousel you'll ever need",
     "main": "slick/slick.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "slick-carousel",
-    "version": "1.5.13",
+    "version": "1.5.14",
     "description": "the last carousel you'll ever need",
     "main": "slick/slick.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "slick-carousel",
-    "version": "1.5.8",
+    "version": "1.5.10",
     "description": "the last carousel you'll ever need",
     "main": "slick/slick.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "slick-carousel",
-    "version": "1.5.11",
+    "version": "1.5.13",
     "description": "the last carousel you'll ever need",
     "main": "slick/slick.js",
     "repository": {

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -6,7 +6,7 @@
 |___/_|_|\___|_|\_(_)/ |___/
                    |__/
 
- Version: 1.5.9
+ Version: 1.5.10
   Author: Ken Wheeler
  Website: http://kenwheeler.github.io
     Docs: http://kenwheeler.github.io/slick
@@ -72,6 +72,7 @@
                 rows: 1,
                 rtl: false,
                 slide: '',
+                slidesGutter: 0,
                 slidesPerRow: 1,
                 slidesToShow: 1,
                 slidesToScroll: 1,
@@ -272,7 +273,7 @@
                     duration: _.options.speed,
                     easing: _.options.easing,
                     step: function(now) {
-                        now = Math.ceil(now);
+                        now = Math.ceil(now) - _.options.slidesGutter;
                         if (_.options.vertical === false) {
                             animProps[_.animType] = 'translate(' +
                                 now + 'px, 0px)';
@@ -293,7 +294,7 @@
             } else {
 
                 _.applyTransition();
-                targetLeft = Math.ceil(targetLeft);
+                targetLeft = Math.ceil(targetLeft) - _.options.slidesGutter;
 
                 if (_.options.vertical === false) {
                     animProps[_.animType] = 'translate3d(' + targetLeft + 'px, 0px, 0px)';
@@ -490,7 +491,9 @@
         _.$slides =
             _.$slider
                 .children( _.options.slide + ':not(.slick-cloned)')
-                .addClass('slick-slide');
+                .addClass('slick-slide')
+                  .css('padding-right', _.options.slidesGutter);
+
 
         _.slideCount = _.$slides.length;
 
@@ -1734,8 +1737,9 @@
             _.$slideTrack.height(Math.ceil((_.$slides.first().outerHeight(true) * _.$slideTrack.children('.slick-slide').length)));
         }
 
-        var offset = _.$slides.first().outerWidth(true) - _.$slides.first().width();
+        var offset = _.$slides.first().outerWidth(true) - _.$slides.first().width() - _.options.slidesGutter;
         if (_.options.variableWidth === false) _.$slideTrack.children('.slick-slide').width(_.slideWidth - offset);
+        if (_.options.slidesGutter > 0) _.$slideTrack.width(_.$slideTrack.width() + (_.options.slidesGutter * _.$slides.length));
 
     };
 

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -6,7 +6,7 @@
 |___/_|_|\___|_|\_(_)/ |___/
                    |__/
 
- Version: 1.5.12
+ Version: 1.5.14
   Author: Ken Wheeler
  Website: http://kenwheeler.github.io
     Docs: http://kenwheeler.github.io/slick

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -6,7 +6,7 @@
 |___/_|_|\___|_|\_(_)/ |___/
                    |__/
 
- Version: 1.5.8
+ Version: 1.5.9
   Author: Ken Wheeler
  Website: http://kenwheeler.github.io
     Docs: http://kenwheeler.github.io/slick

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -685,7 +685,7 @@
         switch (event.data.message) {
 
             case 'previous':
-                slideOffset = indexOffset === 0 ? _.options.slidesToScroll : _.options.slidesToShow - indexOffset;
+                slideOffset = indexOffset === 0 ? Math.abs(_.options.slidesToScroll) : _.options.slidesToShow - indexOffset;
                 if (_.slideCount > _.options.slidesToShow) {
                     _.slideHandler(_.currentSlide - slideOffset, false, dontAnimate);
                 }
@@ -2112,7 +2112,7 @@
 
         _.currentLeft = _.swipeLeft === null ? slideLeft : _.swipeLeft;
 
-        if (_.options.infinite === false && _.options.centerMode === false && (index < 0 || index > _.getDotCount() * _.options.slidesToScroll)) {
+        if (_.options.infinite === false && _.options.centerMode === false && (index < 0 || (_.options.dots && index > _.getDotCount() * _.options.slidesToScroll))) {
             if (_.options.fade === false) {
                 targetSlide = _.currentSlide;
                 if (dontAnimate !== true) {

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1090,12 +1090,14 @@
             }
         }
         else {
-            if (slideIndex > 0) {
-                targetLeft -= (slideIndex > 1) ?
-                    (_.options.slidesGutter * 2) : _.options.slidesGutter;
+            if (slideIndex > 1) {
+                targetLeft -= _.options.slidesGutter * 2;
+            }
+            else if (slideIndex > 0) {
+                targetLeft -=  _.options.slidesGutter;
             }
 
-            if (_.$slides.length > 2 && slideIndex === (_.$slides.length - 1)) {
+            if (slideIndex === (_.slideCount - 1) && _.$slides.length > 3) {
                 targetLeft -= _.options.slidesGutter;
             }
         }

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1091,7 +1091,8 @@
         }
         else {
             if (slideIndex > 0) {
-                targetLeft -= _.options.slidesGutter;
+                targetLeft -= (slideIndex > 1) ?
+                    (_.options.slidesGutter * 2) : _.options.slidesGutter;
             }
 
             if (_.$slides.length > 2 && slideIndex === (_.$slides.length - 1)) {

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -6,7 +6,7 @@
 |___/_|_|\___|_|\_(_)/ |___/
                    |__/
 
- Version: 1.5.10
+ Version: 1.5.11
   Author: Ken Wheeler
  Website: http://kenwheeler.github.io
     Docs: http://kenwheeler.github.io/slick
@@ -273,7 +273,7 @@
                     duration: _.options.speed,
                     easing: _.options.easing,
                     step: function(now) {
-                        now = Math.ceil(now) - _.options.slidesGutter;
+                        now = Math.ceil(now);
                         if (_.options.vertical === false) {
                             animProps[_.animType] = 'translate(' +
                                 now + 'px, 0px)';
@@ -294,7 +294,7 @@
             } else {
 
                 _.applyTransition();
-                targetLeft = Math.ceil(targetLeft) - _.options.slidesGutter;
+                targetLeft = Math.ceil(targetLeft);
 
                 if (_.options.vertical === false) {
                     animProps[_.animType] = 'translate3d(' + targetLeft + 'px, 0px, 0px)';
@@ -1089,6 +1089,15 @@
                 targetLeft += (_.$list.width() - targetSlide.outerWidth()) / 2;
             }
         }
+        else {
+            if (slideIndex > 0) {
+                targetLeft -= _.options.slidesGutter;
+            }
+
+            if (slideIndex === (_.$slides.length - 1)) {
+                targetLeft -= _.options.slidesGutter;
+            }
+        }
 
         return targetLeft;
 
@@ -1728,7 +1737,11 @@
 
         if (_.options.vertical === false && _.options.variableWidth === false) {
             _.slideWidth = Math.ceil(_.listWidth / _.options.slidesToShow);
-            _.$slideTrack.width(Math.ceil((_.slideWidth * _.$slideTrack.children('.slick-slide').length)));
+            var trackWidth = Math.ceil((_.slideWidth * _.$slideTrack.children('.slick-slide').length));
+
+            (_.options.slidesGutter > 0) ?
+                _.$slideTrack.width(trackWidth + (_.options.slidesGutter * _.$slides.length)) :
+                _.$slideTrack.width(trackWidth);
 
         } else if (_.options.variableWidth === true) {
             _.$slideTrack.width(5000 * _.slideCount);
@@ -1739,7 +1752,6 @@
 
         var offset = _.$slides.first().outerWidth(true) - _.$slides.first().width() - _.options.slidesGutter;
         if (_.options.variableWidth === false) _.$slideTrack.children('.slick-slide').width(_.slideWidth - offset);
-        if (_.options.slidesGutter > 0) _.$slideTrack.width(_.$slideTrack.width() + (_.options.slidesGutter * _.$slides.length));
 
     };
 

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -6,7 +6,7 @@
 |___/_|_|\___|_|\_(_)/ |___/
                    |__/
 
- Version: 1.5.11
+ Version: 1.5.12
   Author: Ken Wheeler
  Website: http://kenwheeler.github.io
     Docs: http://kenwheeler.github.io/slick
@@ -1094,7 +1094,7 @@
                 targetLeft -= _.options.slidesGutter;
             }
 
-            if (slideIndex === (_.$slides.length - 1)) {
+            if (_.$slides.length > 2 && slideIndex === (_.$slides.length - 1)) {
                 targetLeft -= _.options.slidesGutter;
             }
         }


### PR DESCRIPTION
When doing something like:
```
slick.slick(
    'slickSetOption',
    'slidesToScroll', direction
);

slick.slick('slickPlay');
```
And changing direction to -1 it will break. Goes into infinitive loop inside _.getDotCount. Added extra checking - not doing doCount if they are not enabled and "step" should always be a positive number.