### PR TITLE
Use event.currentTarget in changeSlide method

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -666,7 +666,7 @@
     Slick.prototype.changeSlide = function(event, dontAnimate) {
 
         var _ = this,
-            $target = $(event.target),
+            $target = $(event.currentTarget),
             indexOffset, slideOffset, unevenOffset;
 
         // If target is a link, prevent default action.


### PR DESCRIPTION
This makes sure we are looking at the intended element and still call `.preventDefault()` if the given `nextArrow/prevArrow` contains any children.

See #1585. Not sure how well this plays with the accessibility stuff, where is the test suite? :)