### PR TITLE
Obey 'slide' option when removing clones

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -799,6 +799,18 @@
 
     };
 
+    Slick.prototype.cleanUpCloned = function() {
+
+        var _ = this,
+            $cloned = $('.slick-cloned', _.$slider);
+
+        if(_.options.slide != ""){
+            $cloned = $cloned.filter(_.options.slide);
+        }
+
+        $cloned.remove();
+    };
+
     Slick.prototype.clickHandler = function(event) {
 
         var _ = this;
@@ -821,7 +833,7 @@
 
         _.cleanUpEvents();
 
-        $('.slick-cloned', _.$slider).detach();
+        _.cleanUpCloned();
 
         if (_.$dots) {
             _.$dots.remove();
@@ -2452,7 +2464,7 @@
 
         var _ = this;
 
-        $('.slick-cloned', _.$slider).remove();
+        _.cleanUpCloned();
 
         if (_.$dots) {
             _.$dots.remove();


### PR DESCRIPTION
Hi,
having slick carousel inside slick carousel, and trying to delete slide from root carousel is causing to break children carousel slides. It is because when removing clones from root carousel, options.slide is not obeyed as it should be, and by deleting root carousel slide, children carousel slides are also deleted.

Link to JSFiddle: http://jsfiddle.net/twuxy6b0/2/
Instructions: Press "remove first slide from c1" button. First slide is removed from root carousel.
Expected result: States and slides of children carousels stay intact.
Actual result: Some of children' slides are deleted. Infinite scroll does not longer work properly.

This pull request fixes this issue, by adding filter _.options.slide to jquery selector during Slick.prototype.destroy and Slick.prototype.unload 