### PR TITLE
Fixes #1581 - Reset current slide at breakpoint

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1512,8 +1512,13 @@
 
     Slick.prototype.refresh = function( initializing ) {
 
-        var _ = this,
-            currentSlide = _.currentSlide;
+        var _ = this, currentSlide;
+
+        if (_.slideCount <= _.options.slidesToShow) {
+            _.currentSlide = 0;
+        }
+
+         currentSlide = _.currentSlide;
 
         _.destroy(true);
 


### PR DESCRIPTION
This was raised in #1581 , the `currentSlide` was being maintained even if the amount of slides was less/equal than the visible ones... meaning you couldn't scroll back to the beginning if you were not at slide 1 during the brekapoints. Fixed, tested and verified.