### PR TITLE
Add srcset support for data-lazy

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -517,6 +517,7 @@
         }
 
         $('img[data-lazy]', _.$slider).not('[src]').addClass('slick-loading');
+        $('img[data-lazy-srcset]', _.$slider).not('[srcset]').addClass('slick-loading');
 
         _.setupInfinite();
 
@@ -1353,6 +1354,29 @@
                 imageToLoad.src = imageSource;
 
             });
+
+             $('img[data-lazy-srcset]', imagesScope).each(function() {
+
+                var image = $(this),
+                    imageSource = $(this).attr('data-lazy-srcset'),
+                    imageToLoad = document.createElement('img');
+
+                imageToLoad.onload = function() {
+                    image
+                        .animate({ opacity: 0 }, 100, function() {
+                            image
+                                .attr('srcset', imageSource)
+                                .animate({ opacity: 1 }, 200, function() {
+                                    image
+                                        .removeAttr('data-lazy-srcset')
+                                        .removeClass('slick-loading');
+                                });
+                        });
+                };
+
+                imageToLoad.srcset = imageSource;
+
+            });
         }
 
         if (_.options.centerMode === true) {
@@ -1488,9 +1512,10 @@
     Slick.prototype.progressiveLazyLoad = function() {
 
         var _ = this,
-            imgCount, targetImage;
+            imgCount, targetImage, imgCountSrcset, targetImageSrcset;
 
         imgCount = $('img[data-lazy]', _.$slider).length;
+        imgCountSrcset = $('img[data-lazy-srcset]', _.$slider).length;
 
         if (imgCount > 0) {
             targetImage = $('img[data-lazy]', _.$slider).first();
@@ -1504,6 +1529,22 @@
                 })
                 .error(function() {
                     targetImage.removeAttr('data-lazy');
+                    _.progressiveLazyLoad();
+                });
+        }
+
+        if (imgCountSrcset > 0) {
+            targetImageSrcset = $('img[data-lazy-srcset]', _.$slider).first();
+            targetImageSrcset.attr('srcset', targetImageSrcset.attr('data-lazy-srcset')).removeClass('slick-loading').load(function() {
+                    targetImageSrcset.removeAttr('data-lazy-srcset');
+                    _.progressiveLazyLoad();
+
+                    if (_.options.adaptiveHeight === true) {
+                        _.setPosition();
+                    }
+                })
+                .error(function() {
+                    targetImageSrcset.removeAttr('data-lazy-srcset');
                     _.progressiveLazyLoad();
                 });
         }


### PR DESCRIPTION
Hello,

During working with my project, I need to use slick with the picturefill and lazyload the image. I found that slick has `data-lazy` for that, but it links with `src`, so I made some minor modifications to the source code to add support for `data-lazy-srcset` -> `srcset`.
Here is a very simple demo to prove my `data-lazy-srcset` works: https://jsfiddle.net/pwq4g54b/embedded/result/

Thank you.