### PR TITLE
Fix outline around main slick list showing up in various browsers

### DIFF
--- a/slick/slick.css
+++ b/slick/slick.css
@@ -30,9 +30,12 @@
     margin: 0;
     padding: 0;
 }
-.slick-list:focus
+.slick-slide:focus
 {
-    outline: none;
+    outline: 0;
+    -webkit-box-shadow: none !important;
+    -moz-box-shadow: none !important;
+    box-shadow: none !important;
 }
 .slick-list.dragging
 {


### PR DESCRIPTION
slick-list:focus not working to remove the small outline around div. This should fix it.