### PR TITLE
Added arrowsAroundDots option

### DIFF
--- a/slick/slick-theme.scss
+++ b/slick/slick-theme.scss
@@ -131,6 +131,28 @@ $slick-opacity-not-active: 0.25 !default;
     margin-bottom: 30px;
 }
 
+.slick-dots-wrapper {
+    position: absolute;
+    bottom: -45px;
+    display: block;
+    text-align: center;
+    width: 100%;
+    .slick-prev-wrap, .slick-next-wrap {
+        display: inline-block;
+    }
+    .slick-prev, .slick-next {
+        position: relative;
+        top: 0;
+        left: auto;
+        right: auto;
+        margin: 0 10px;
+        @include translate(0, 110%);
+    }
+    .slick-dots {
+        bottom: 0;
+    }
+}
+
 .slick-dots {
     position: absolute;
     bottom: -45px;
@@ -139,6 +161,10 @@ $slick-opacity-not-active: 0.25 !default;
     text-align: center;
     padding: 0;
     width: 100%;
+    .slick-dots-wrapper & {
+        position: relative;
+        display: inline;
+    }
     li {
         position: relative;
         display: inline-block;

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -56,6 +56,7 @@
                 },
                 dots: false,
                 dotsClass: 'slick-dots',
+                arrowsAroundDots: false,
                 draggable: true,
                 easing: 'linear',
                 edgeFriction: 0.35,
@@ -98,6 +99,7 @@
                 currentSlide: 0,
                 direction: 1,
                 $dots: null,
+                $dotsWrapper: null,
                 listWidth: null,
                 listHeight: null,
                 loadIndex: 0,
@@ -479,6 +481,14 @@
                 _.options.appendDots);
 
             _.$dots.find('li').first().addClass('slick-active').attr('aria-hidden', 'false');
+
+            if( _.options.arrowsAroundDots ){
+                _.$dotsWrapper = _.$dots.wrap('<div class="' + _.options.dotsClass + '-wrapper">').parent();
+                _.$dotsWrapper.prepend(_.$prevArrow);
+                _.$dotsWrapper.append(_.$nextArrow);
+                _.$prevArrow.wrap('<div class="slick-prev-wrap">');
+                _.$nextArrow.wrap('<div class="slick-next-wrap">');
+            }
 
         }
 


### PR DESCRIPTION
The arrows will be inserted before and after the dots. I have introduced a dotsClass wrapper div to position the arrows and the list inline. Also the arrows are wrapped to retain the toggled display block option (maybe not necessary). An example SCSS for the option is added to the PR.

Thanks for the nice carousel.