### PR TITLE
Added option to skip specific slides during rotation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -90,6 +90,7 @@ pauseOnDotsHover | boolean | false | Pauses autoplay when a dot is hovered
 respondTo | string | 'window' | Width that responsive object responds to. Can be 'window', 'slider' or 'min' (the smaller of the two).
 responsive | object | null | Object containing breakpoints and settings objects (see demo). Enables settings sets at given screen width. Set settings to "unslick" instead of an object to disable slick at a given breakpoint.
 rows | int | 1 | Setting this to more than 1 initializes grid mode. Use slidesPerRow to set how many slides should be in each row.
+skipSlideIndexes | array | [] | Array of slide indexes that should not be made the active slide and that should be skipped over when sliding to a new slide.
 slide | string | '' | Slide element query
 slidesPerRow | int | 1 | With grid mode intialized via the rows option, this sets how many slides are in each grid row. dver
 slidesToShow | int | 1 | # of slides to show at a time

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -71,6 +71,7 @@
                 responsive: null,
                 rows: 1,
                 rtl: false,
+                skipSlideIndexes: [],
                 slide: '',
                 slidesPerRow: 1,
                 slidesToShow: 1,
@@ -394,7 +395,7 @@
                     _.direction = 0;
                 }
 
-                _.slideHandler(_.currentSlide + _.options.slidesToScroll);
+                _.slideHandler(_.checkNavigable(_.currentSlide + _.options.slidesToScroll, 1));
 
             } else {
 
@@ -404,13 +405,13 @@
 
                 }
 
-                _.slideHandler(_.currentSlide - _.options.slidesToScroll);
+                _.slideHandler(_.checkNavigable(_.currentSlide - _.options.slidesToScroll, -1));
 
             }
 
         } else {
 
-            _.slideHandler(_.currentSlide + _.options.slidesToScroll);
+            _.slideHandler(_.checkNavigable(_.currentSlide + _.options.slidesToScroll, 1));
 
         }
 
@@ -686,14 +687,14 @@
             case 'previous':
                 slideOffset = indexOffset === 0 ? _.options.slidesToScroll : _.options.slidesToShow - indexOffset;
                 if (_.slideCount > _.options.slidesToShow) {
-                    _.slideHandler(_.currentSlide - slideOffset, false, dontAnimate);
+                    _.slideHandler(_.checkNavigable(_.currentSlide - slideOffset, -1), false, dontAnimate);
                 }
                 break;
 
             case 'next':
                 slideOffset = indexOffset === 0 ? _.options.slidesToScroll : indexOffset;
                 if (_.slideCount > _.options.slidesToShow) {
-                    _.slideHandler(_.currentSlide + slideOffset, false, dontAnimate);
+                    _.slideHandler(_.checkNavigable(_.currentSlide + slideOffset, 1), false, dontAnimate);
                 }
                 break;
 
@@ -701,7 +702,7 @@
                 var index = event.data.index === 0 ? 0 :
                     event.data.index || $target.index() * _.options.slidesToScroll;
 
-                _.slideHandler(_.checkNavigable(index), false, dontAnimate);
+                _.slideHandler(_.checkNavigable(index, 0), false, dontAnimate);
                 $target.children().trigger('focus');
                 break;
 
@@ -711,7 +712,7 @@
 
     };
 
-    Slick.prototype.checkNavigable = function(index) {
+    Slick.prototype.checkNavigable = function(index, direction) {
 
         var _ = this,
             navigables, prevNavigable;
@@ -720,11 +721,20 @@
         prevNavigable = 0;
         if (index > navigables[navigables.length - 1]) {
             index = navigables[navigables.length - 1];
+        } else if (index < navigables[0]) {
+            index = navigables[0];
         } else {
             for (var n in navigables) {
-                if (index < navigables[n]) {
-                    index = prevNavigable;
-                    break;
+                if (direction <= 0) {
+                    if (index < navigables[n]) {
+                        index = prevNavigable;
+                        break;
+                    }
+                } else {
+                    if (index <= navigables[n]) {
+                        index = navigables[n];
+                        break;
+                    }
                 }
                 prevNavigable = navigables[n];
             }
@@ -1106,6 +1116,7 @@
             breakPoint = 0,
             counter = 0,
             indexes = [],
+            skipIndexes = _.options.skipSlideIndexes,
             max;
 
         if (_.options.infinite === false) {
@@ -1114,10 +1125,15 @@
             breakPoint = _.options.slidesToScroll * -1;
             counter = _.options.slidesToScroll * -1;
             max = _.slideCount * 2;
+            for (var n in _.options.skipSlideIndexes) {
+                skipIndexes.push(_.options.skipSlideIndexes[n] + _.slideCount);
+            }
         }
 
         while (breakPoint < max) {
-            indexes.push(breakPoint);
+            if ($.inArray(breakPoint, _.options.skipSlideIndexes) == -1) {
+                indexes.push(breakPoint);
+            }
             breakPoint = counter + _.options.slidesToScroll;
             counter += _.options.slidesToScroll <= _.options.slidesToShow ? _.options.slidesToScroll : _.options.slidesToShow;
         }
@@ -2094,7 +2110,7 @@
 
         }
 
-        _.slideHandler(index);
+        _.slideHandler(_.checkNavigable(index, 0));
 
     };
 
@@ -2287,7 +2303,7 @@
 
             switch (_.swipeDirection()) {
                 case 'left':
-                    slideCount = _.options.swipeToSlide ? _.checkNavigable(_.currentSlide + _.getSlideCount()) : _.currentSlide + _.getSlideCount();
+                    slideCount = _.options.swipeToSlide ? _.checkNavigable(_.currentSlide + _.getSlideCount(), -1) : _.currentSlide + _.getSlideCount();
                     _.slideHandler(slideCount);
                     _.currentDirection = 0;
                     _.touchObject = {};
@@ -2295,7 +2311,7 @@
                     break;
 
                 case 'right':
-                    slideCount = _.options.swipeToSlide ? _.checkNavigable(_.currentSlide - _.getSlideCount()) : _.currentSlide - _.getSlideCount();
+                    slideCount = _.options.swipeToSlide ? _.checkNavigable(_.currentSlide - _.getSlideCount(), 1) : _.currentSlide - _.getSlideCount();
                     _.slideHandler(slideCount);
                     _.currentDirection = 1;
                     _.touchObject = {};


### PR DESCRIPTION
Added a new option (skipSlideIndexes) which allows you to specify an array of slide indexes to skip over or exclude from becoming the central, active slide.

New functionality: http://jsfiddle.net/6sq969w8/
With infinite scrolling: http://jsfiddle.net/uj0112rm/1/
Backwards compatible: http://jsfiddle.net/bq3hjybv/1/

Works well with multiple slidesToShow and slidesToScroll. Set swipeToSlide to true if you want it to work for mobile touch events.

Tested in Chrome 45, FF 41, and IE 11

BTW... Thanks for the awesome carousel.
