### PR TITLE
Update to slick.css to fix a bug

### DIFF
--- a/slick/slick.css
+++ b/slick/slick.css
@@ -81,6 +81,7 @@
 
     height: 100%;
     min-height: 1px;
+    outline-width: 0;
 }
 [dir='rtl'] .slick-slide
 {


### PR DESCRIPTION
Found a bug when clicking the prev and next arrows it highlights a blue outline around the last slide within a slideshow or autoscroll.
This is not noticeable with a blue background, however with a white background it is very noticeable.

This bug effects every carousel/slideshow/autoscroll.

This is also noticeable on upon removing the blue background:
http://kenwheeler.github.io/slick/

This change will fix it with "outline-width: 0;" on the slide.
![screen shot 2015-09-29 at 11 47 22 am](https://cloud.githubusercontent.com/assets/5797912/10171469/e2cf35b2-669f-11e5-94d4-1449b6d96abc.png)

![screen shot 2015-09-29 at 11 47 53 am](https://cloud.githubusercontent.com/assets/5797912/10171480/f4127fd2-669f-11e5-9b45-19275b78dd66.png)

![screen shot 2015-09-29 at 11 46 47 am](https://cloud.githubusercontent.com/assets/5797912/10171454/cf9ef43c-669f-11e5-8fe8-7e3896dc46c8.png)