### PR TITLE
Prevent checkResponsive from executing immediately after an unslick

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -579,9 +579,15 @@
     Slick.prototype.checkResponsive = function(initial, forceUpdate) {
 
         var _ = this,
-            breakpoint, targetBreakpoint, respondToWidth, triggerBreakpoint = false;
-        var sliderWidth = _.$slider.width();
-        var windowWidth = window.innerWidth || $(window).width();
+            breakpoint, targetBreakpoint, respondToWidth, sliderWidth, windowWidth, triggerBreakpoint = false;
+
+        if (_.unslicked) {
+            // This could occur if unslick is called in an external window.resize handler
+            return;
+        }
+
+        sliderWidth = _.$slider.width();
+        windowWidth = window.innerWidth || $(window).width();
 
         if (_.respondTo === 'window') {
             respondToWidth = windowWidth;


### PR DESCRIPTION
In this example:  http://jsfiddle.net/dzzcd05v/1/ the slick gets "unslicked" when the window is above 800px wide and then reinitialized when it is sized at or below 800px.  This works fine unless you resize quickly from less than 500px to greater 800px.  In that case you will see the slick does not get disabled.  This is because slick's internal "resize" handler is firing after ours and reinitializing the slick immediately after we call unslick.  The fix is simply to check for _.unslicked in the resize handler and abort if _.unslicked === true.