### PR TITLE
Make prev & next buttons work with touch displays

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -754,8 +754,8 @@
         }
 
         if (_.options.arrows === true && _.slideCount > _.options.slidesToShow) {
-            _.$prevArrow && _.$prevArrow.off('click.slick', _.changeSlide);
-            _.$nextArrow && _.$nextArrow.off('click.slick', _.changeSlide);
+            _.$prevArrow && _.$prevArrow.off('click.slick touchstart.slick', _.changeSlide);
+            _.$nextArrow && _.$nextArrow.off('click.slick touchstart.slick', _.changeSlide);
         }
 
         _.$list.off('touchstart.slick mousedown.slick', _.swipeHandler);
@@ -1204,10 +1204,10 @@
         var _ = this;
 
         if (_.options.arrows === true && _.slideCount > _.options.slidesToShow) {
-            _.$prevArrow.on('click.slick', {
+            _.$prevArrow.on('click.slick touchstart.slick', {
                 message: 'previous'
             }, _.changeSlide);
-            _.$nextArrow.on('click.slick', {
+            _.$nextArrow.on('click.slick touchstart.slick', {
                 message: 'next'
             }, _.changeSlide);
         }


### PR DESCRIPTION
Hey Ken,

I had issues, clicking on the next and prev buttons on mobile devices.
(Since, they only track _click_ events)

What do you think of also tracking the _touchstart_ events?

Best regards,
Benedikt