### PR TITLE
Centralizing Slides

### DIFF
--- a/slick/slick.css
+++ b/slick/slick.css
@@ -55,6 +55,7 @@
     position: relative;
     top: 0;
     left: 0;
+    margin: 0 auto;
 
     display: block;
 }

--- a/slick/slick.less
+++ b/slick/slick.less
@@ -43,6 +43,7 @@
 .slick-track {
     position: relative;
     left: 0;
+    margin: 0 auto;
     top: 0;
     display: block;
 

--- a/slick/slick.scss
+++ b/slick/slick.scss
@@ -43,6 +43,7 @@
 .slick-track {
     position: relative;
     left: 0;
+    margin: 0 auto;
     top: 0;
     display: block;
 


### PR DESCRIPTION

![centralizing-slides](https://cloud.githubusercontent.com/assets/1820920/10263096/27362ff2-69b7-11e5-838d-09828acb138d.png)

Added margin auto on slick-track, to center slides if no have a minimum in the cases of dynamic slides