### PR TITLE
add jspm configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,23 @@
     "license": "MIT",
     "bugs": {
         "url": "https://github.com/kenwheeler/slick/issues"
+    },
+    "jspm": {
+        "main": "slick",
+        "files": null,
+        "directories": {
+            "lib": "slick"
+        },
+        "shim": {
+            "slick": {
+                "deps": [
+                    "jquery"
+                ],
+                "exports": "$"
+            }
+        },
+        "dependencies": {
+            "jquery": "github:components/jquery"
+        }
     }
 }


### PR DESCRIPTION
This enables installing slick with the jspm package manager via `jspm install slick`.