### PR TITLE
Ensure updated settings persist when merging with breakpoint options

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1820,7 +1820,7 @@
                 }
             }
         } else {
-            _.options[option] = value;
+            _.originalSettings[option] = _.options[option] = value;
         }
 
         if (refresh === true) {


### PR DESCRIPTION
Scenario: A user clicks a button to trigger a change in your carousel layout. You call on `slickSetOption` to apply the changes.

If you aren't working with breakpoints, this wouldn't be an issue, but if you are, slick merges the breakpoint settings with `_.originalSettings` (not `_.options`). The problem is that `slickSetOption` only applies the updated value to `_.options`. If the user is currently in a breakpoint, it's going to wipe out your change immediately.

This PR passes the changed option along to `_.originalSettings`.