### PR TITLE
Add slickSetOptions to override multiple options at once

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -178,6 +178,7 @@ slickFilter | filter : selector or function | Filters slides using jQuery .filte
 slickUnfilter | | Removes applied filter
 slickGetOption | option : string(option name) | Gets an option value.
 slickSetOption | option : string(option name), value : depends on option, refresh : boolean | Sets an option live. Set refresh to true if it is an option that changes the display
+slickSetOptions | options : object(key value pairs of options to override), refresh : boolean | Sets options live. Set refresh to true if any of the options will change the display
 
 
 #### Example

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1830,6 +1830,20 @@
 
     };
 
+    Slick.prototype.setOptions = Slick.prototype.slickSetOptions = function(options, refresh) {
+
+        var _ = this;
+
+        $.each(options, function(option, value) {
+            _.setOption(option, value);
+        });
+
+        if (refresh === true) {
+            _.unload();
+            _.reinit();
+        }
+    };
+
     Slick.prototype.setPosition = function() {
 
         var _ = this;


### PR DESCRIPTION
I chose to run the options through slickSetOption in order to reuse the breakpoint logic. I also chose to not pass along the `refresh` param to slickSetOption so that it only runs once for the collection of option changes instead of for each option.

http://jsfiddle.net/vbeazhpd/5/

resolves #821