### PR TITLE
Reenable the .dragging class

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -91,7 +91,6 @@
 
             _.initials = {
                 animating: false,
-                dragging: false,
                 autoPlayTimer: null,
                 currentDirection: 0,
                 currentLeft: null,
@@ -2271,7 +2270,7 @@
         var _ = this,
             slideCount;
 
-        _.dragging = false;
+        _.$list.removeClass('dragging');
 
         _.shouldClick = (_.touchObject.swipeLength > 10) ? false : true;
 
@@ -2358,7 +2357,7 @@
 
         touches = event.originalEvent !== undefined ? event.originalEvent.touches : null;
 
-        if (!_.dragging || touches && touches.length !== 1) {
+        if (!_.$list.hasClass('dragging') || touches && touches.length !== 1) {
             return false;
         }
 
@@ -2441,7 +2440,7 @@
         _.touchObject.startX = _.touchObject.curX = touches !== undefined ? touches.pageX : event.clientX;
         _.touchObject.startY = _.touchObject.curY = touches !== undefined ? touches.pageY : event.clientY;
 
-        _.dragging = true;
+        _.$list.addClass('dragging');
 
     };
 


### PR DESCRIPTION
This pull request reverts ["record dragging state on Slick object instead of css class"](https://github.com/kenwheeler/slick/commit/8e3d9b8542a5ac0bbca04c03bfcb5f0fc2793f45). The problem with that commit is the CSS for the `.dragging` state is no longer applied (which changes the cursor appearance). Reverting the commit reenables the ability to provide styling for the dragging state.
