### PR TITLE
Fix bug with "variableWidth: true" and and "rtl: true"

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1075,7 +1075,15 @@
                 targetSlide = _.$slideTrack.children('.slick-slide').eq(slideIndex + _.options.slidesToShow);
             }
 
-            targetLeft = targetSlide[0] ? targetSlide[0].offsetLeft * -1 : 0;
+            if (_.options.rtl === true) {
+                if (targetSlide[0]) {
+                    targetLeft = (_.$slideTrack.width() - targetSlide[0].offsetLeft - targetSlide.width()) * -1;
+                } else {
+                    targetLeft =  0;
+                }
+            } else {
+                targetLeft = targetSlide[0] ? targetSlide[0].offsetLeft * -1 : 0;
+            }
 
             if (_.options.centerMode === true) {
                 if (_.slideCount <= _.options.slidesToShow || _.options.infinite === false) {
@@ -1083,7 +1091,17 @@
                 } else {
                     targetSlide = _.$slideTrack.children('.slick-slide').eq(slideIndex + _.options.slidesToShow + 1);
                 }
-                targetLeft = targetSlide[0] ? targetSlide[0].offsetLeft * -1 : 0;
+
+                if (_.options.rtl === true) {
+                    if (targetSlide[0]) {
+                        targetLeft = (_.$slideTrack.width() - targetSlide[0].offsetLeft - targetSlide.width()) * -1;
+                    } else {
+                        targetLeft =  0;
+                    }
+                } else {
+                    targetLeft = targetSlide[0] ? targetSlide[0].offsetLeft * -1 : 0;
+                }
+
                 targetLeft += (_.$list.width() - targetSlide.outerWidth()) / 2;
             }
         }


### PR DESCRIPTION
@kenwheeler First of, Thanks for an awesome plugin :smile: 

Bug reproduced: http://jsfiddle.net/pazaricha/qy18dm5k/
Bug fixed: http://jsfiddle.net/pazaricha/7uLwo1hu/

This works both with the following settings: 
```javascript
centerMode: true || false
infinite: true || false
```
`slidesToShow & slidesToScroll` are irrelevant as far as I understand when `variableWidth` is set to `true`. (correct me if I am wrong on this)

I'd live to hear your comments and also if you'd like me to bump the version number across the files I will be happy to do so.
