### PR TITLE
changed inline width style to min-width to fix ios flexbox issue

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1769,7 +1769,9 @@
         }
 
         var offset = _.$slides.first().outerWidth(true) - _.$slides.first().width();
-        if (_.options.variableWidth === false) _.$slideTrack.children('.slick-slide').width(_.slideWidth - offset);
+        if (_.options.variableWidth === false) _.$slideTrack.children('.slick-slide').css({
+      'min-width': _.slideWidth - offset
+    });
 
     };
 


### PR DESCRIPTION
When using a flexbox layout, the slider has no width on iOS, min-width fixes this. This fixes the issue: #1906 