### PR TITLE
Whitish effect when slides are switched

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -60,6 +60,7 @@
                 easing: 'linear',
                 edgeFriction: 0.35,
                 fade: false,
+                fadeInFirst: false,
                 focusOnSelect: false,
                 infinite: true,
                 initialSlide: 0,
@@ -2205,12 +2206,20 @@
 
         if (_.options.fade === true) {
             if (dontAnimate !== true) {
+                if (_.options.fadeInFirst === false) {
 
-                _.fadeSlideOut(oldSlide);
+                    _.fadeSlideOut(oldSlide);
 
-                _.fadeSlide(animSlide, function() {
-                    _.postSlide(animSlide);
-                });
+                    _.fadeSlide(animSlide, function() {
+                        _.postSlide(animSlide);
+                    });
+                } else {
+
+                    _.fadeSlide(animSlide, function() {
+                        _.fadeSlideOut(oldSlide);
+                        _.postSlide(animSlide);
+                    });
+                }
 
             } else {
                 _.postSlide(animSlide);


### PR DESCRIPTION
Hello )
Thank you for a great job.
This slider plugin in really nice one.
And also your code is organised really well!

I have an issue with switching slides:
when it happens in my case — I see a whitish effect.
![whitish](https://cloud.githubusercontent.com/assets/498934/11489938/ea3ff342-97e4-11e5-8dd7-6b5e45c01ff4.gif)

This happens maybe because images in my case have almost the same background.
So that it is easier to see that these images are similar.

This effect is happening because we start to fade out old slide and fade in new slide at the same time https://github.com/kenwheeler/slick/blob/master/slick/slick.js#L2209.

A simple fix could be to move `_.fadeSlideOut(oldSlide);` inside `_.fadeSlide` callback so that we start to fade out old slide when new one is already fully visible.
This looks better:
![ok](https://cloud.githubusercontent.com/assets/498934/11489940/f109d5c6-97e4-11e5-86c8-e5493227a77b.gif)

Is there any chance that this kind of pull request will be accepted? :)
Thank you