### PR TITLE
loadImages: clone image instead of creating a new one

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1354,7 +1354,7 @@
 
                 var image = $(this),
                     imageSource = $(this).attr('data-lazy'),
-                    imageToLoad = document.createElement('img');
+                    imageToLoad = image.clone(); // The image might have attribute sizes, important for Client Hints
 
                 imageToLoad.onload = function() {
                     image


### PR DESCRIPTION
without important origin attributes like sizes