### PR TITLE
Conform bower.json main property to specification

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,11 @@
 {
     "name": "slick-carousel",
-    "main": ["slick/slick.min.js", "slick/slick.css", "slick/slick-theme.css", "slick/fonts/*"],
+    "main": [
+        "slick/slick.js",
+        "slick/slick.css",
+        "slick/slick.less",
+        "slick/slick.scss"
+    ],
     "version": "1.5.9",
     "homepage": "https://github.com/kenwheeler/slick",
     "authors": [


### PR DESCRIPTION
Although there are also slick themes, those aren't entry-points for the main package/module. Instead, I think the theme's file name would be better stated as a variable to be included within the entry-point. Fonts are assets, so they aren't entry-points. Again, the fonts files (or at least the font directory) could be declared as variables and referenced that way.

Without a properly specified main property, developers who rely on it are forced to resort to [overrides](https://github.com/taptapship/wiredep#bower-overrides), assuming they're available. Certain asset pipelines may not make overriding possible because the override property is not an official Bower specification, which is why it's preferred to specify it properly in the package's own repository.

For more information, see: https://github.com/bower/spec/blob/master/json.md#main