### PR TITLE
[lazyLoading] Fix partiallly visible elements

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1384,7 +1384,7 @@
             }
         } else {
             rangeStart = _.options.infinite ? _.options.slidesToShow + _.currentSlide : _.currentSlide;
-            rangeEnd = rangeStart + _.options.slidesToShow;
+            rangeEnd = Math.ceil(rangeStart + _.options.slidesToShow);
             if (_.options.fade === true) {
                 if (rangeStart > 0) rangeStart--;
                 if (rangeEnd <= _.slideCount) rangeEnd++;


### PR DESCRIPTION
To pay more attention to the scroller we want to display 60% of the last picture only. We set ```slidesToShow=4.6```. Without this patch the 4.6 value is used to slice the array which results in the ```4``` beeing used.
This patch uses the ```Match.ceil()``` to fix this.
