### PR TITLE
make overriding sass variables possible when used with compass

### DIFF
--- a/slick/slick-theme.scss
+++ b/slick/slick-theme.scss
@@ -26,7 +26,7 @@ $slick-opacity-not-active: 0.25 !default;
         @return image-url($url);
     }
     @else {
-        @return url($slick-font-path-default + $url);
+        @return url($slick-loader-path-default + $url);
     }
 }
 

--- a/slick/slick-theme.scss
+++ b/slick/slick-theme.scss
@@ -2,9 +2,9 @@
 
 // Default Variables
 
-$slick-font-path: "./fonts/" !default;
+$slick-font-path-default: "./fonts/" !default;
 $slick-font-family: "slick" !default;
-$slick-loader-path: "./" !default;
+$slick-loader-path-default: "./" !default;
 $slick-arrow-color: white !default;
 $slick-dot-color: black !default;
 $slick-dot-color-active: $slick-dot-color !default;
@@ -17,20 +17,30 @@ $slick-opacity-on-hover: 1 !default;
 $slick-opacity-not-active: 0.25 !default;
 
 @function slick-image-url($url) {
+
+    @if variable-exists(slick-loader-path) {
+        @return url($slick-loader-path + $url);
+    }
+
     @if function-exists(image-url) {
         @return image-url($url);
     }
     @else {
-        @return url($slick-loader-path + $url);
+        @return url($slick-font-path-default + $url);
     }
 }
 
 @function slick-font-url($url) {
+    
+    @if variable-exists(slick-font-path) {
+        @return url($slick-font-path + $url);
+    }
+    
     @if function-exists(font-url) {
         @return font-url($url);
     }
     @else {
-        @return url($slick-font-path + $url);
+        @return url($slick-font-path-default + $url);
     }
 }
 


### PR DESCRIPTION
When overriding the sass variables "$slick-loader-path" and "$slick-font-path" the resource paths will not actually change because slick-theme.scss will call compass function image-url() even if the variable has been overridden. This basically makes it impossible to override those variables when used with compass, as the function image-url() will always exist and if not specified, return some default value.

This fixes that. If the variable has been set before, it will take the overridden value. If it has not been set, it will check the existence of the image-url() function and use that if it exists, otherwise it will default to the original values.

Also see this SO Question: http://stackoverflow.com/questions/34572876/is-it-possible-to-not-use-turn-off-compass-url-helpers-on-purpose