### PR TITLE
Added setting to stop event propagation and allow nested carousels

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2333,6 +2333,10 @@
 
         var _ = this;
 
+		if (_.options.stopSwipePropagation){
+			event.stopPropagation();
+		}
+
         if ((_.options.swipe === false) || ('ontouchend' in document && _.options.swipe === false)) {
             return;
         } else if (_.options.draggable === false && event.type.indexOf('mouse') !== -1) {


### PR DESCRIPTION
I need to have nested carousels and allow the user to swipe without moving the parent carousel. I've added the ability to stop the user input event from propagating to the parent carousel via a setting variable. 