### PR TITLE
Fix keep a reference to each Slick instance

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2658,8 +2658,10 @@
             i,
             ret;
         for (i = 0; i < l; i++) {
-            if (typeof opt == 'object' || typeof opt == 'undefined')
+            if (typeof opt == 'object' || typeof opt == 'undefined') {
                 _[i].slick = new Slick(_[i], opt);
+                $(_[i]).data('slickInstance', _[i].slick);
+            }
             else
                 ret = _[i].slick[opt].apply(_[i].slick, args);
             if (typeof ret != 'undefined') return ret;


### PR DESCRIPTION
When you have multiple slider on the same page there no way to get access the instance for each of them 
So storing an instance with the element fix this issue.

that works with this fix:
```
 $('.my-slick-slider-element').each(function() {
            var slick = $(this).data('slickInstance');
            slick.slickSetOption('arrows',false);
});
```