### PR TITLE
fixing bug when "init" event fires before breakpoint is initialized

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -175,7 +175,6 @@
 
             _.registerBreakpoints();
             _.init(true);
-            _.checkResponsive(true);
 
         }
 
@@ -1204,6 +1203,7 @@
             _.initializeEvents();
             _.updateArrows();
             _.updateDots();
+            _.checkResponsive(true);
 
         }
 


### PR DESCRIPTION
Hi,

We have a problem with "init" event and option "slidesToShow" on multiple breakpoints.
In short, the "init" event occurs before the checkResponsive() action and final set of clonned elements is diffirent from the "init" moment.

Detailed description on the jsfiddle link:
http://jsfiddle.net/h1u7ohzt/2/

Openmarco team