### PR TITLE
fix jumping when infinite is off

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2131,6 +2131,10 @@
 
         sync = sync || false;
 
+        if (_.options.infinite === false && (index < 0 || index >= _.slideCount)) {
+            return;
+        }
+
         if (_.animating === true && _.options.waitForAnimate === true) {
             return;
         }


### PR DESCRIPTION
Before:
http://jsfiddle.net/co8po9fr/2/
Click fast 5 times `prev`, then `next` and `prev`. Slides are jumping.

After:
http://jsfiddle.net/q1qznouw/319/
Same instruction and everything is ok.
