### PR TITLE
Issue #1446 - Pause on Hover fix

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -170,7 +170,7 @@ unslick |  | Destroys Slick
 slickNext |  |  Triggers next slide
 slickPrev | | Triggers previous slide
 slickPause | | Pause Autoplay
-slickPlay | | Start Autoplay
+slickPlay | | Start Autoplay (_will also set `autoplay` option to `true`_)
 slickGoTo | index : int, dontAnimate : bool | Goes to slide by index, skipping animation if second parameter is set to true
 slickCurrentSlide |  |  Returns the current slide index
 slickAdd | element : html or DOM object, index: int, addBefore: bool | Add a slide. If an index is provided, will add at that index, or before if addBefore is set. If no index is provided, add to the end or to the beginning if addBefore is set. Accepts HTML String || Object

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1461,6 +1461,7 @@
         var _ = this;
 
         _.paused = false;
+        _.options.autoplay = true;
         _.autoPlay();
 
     };
@@ -2079,7 +2080,7 @@
 
         var _ = this;
 
-        if (_.options.autoplay === true && _.options.pauseOnHover === true) {
+        if ( _.options.autoplay === true && _.options.pauseOnHover === true ) {
             _.paused = paused;
             if (!paused) {
                 _.autoPlay();


### PR DESCRIPTION
Seems that when programmatically setting `slickPlay()` it actually
is triggering `autoPlay()` but never setting `options.autoplay` to `true`
and thus the `mouseenter` even cannot verify that autoplay is running and
will never pause the slider.

Fixes #1446 by setting `_.options.autoplay` to `true` when using
`slickPlay()` ... also updated README to document it.