### PR TITLE
Fixes #1248

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -318,14 +318,23 @@
 
     };
 
-    Slick.prototype.asNavFor = function(index) {
-
+    Slick.prototype.getNavTarget = function() {
+        
         var _ = this,
             asNavFor = _.options.asNavFor;
 
         if ( asNavFor && asNavFor !== null ) {
             asNavFor = $(asNavFor).not(_.$slider);
         }
+
+        return asNavFor;
+
+    };
+
+    Slick.prototype.asNavFor = function(index) {
+
+        var _ = this,
+            asNavFor = _.getNavTarget();
 
         if ( asNavFor !== null && typeof asNavFor === 'object' ) {
             asNavFor.each(function() {
@@ -2118,7 +2127,7 @@
     Slick.prototype.slideHandler = function(index, sync, dontAnimate) {
 
         var targetSlide, animSlide, oldSlide, slideLeft, targetLeft = null,
-            _ = this;
+            _ = this, navTarget;
 
         sync = sync || false;
 
@@ -2198,6 +2207,17 @@
         _.currentSlide = animSlide;
 
         _.setSlideClasses(_.currentSlide);
+        
+        if ( _.options.asNavFor ) {
+            
+            navTarget = _.getNavTarget();
+            navTarget = navTarget.slick('getSlick');
+
+            if ( navTarget.slideCount <= navTarget.options.slidesToShow ) {
+                navTarget.setSlideClasses(_.currentSlide);
+            }
+
+        }
 
         _.updateDots();
         _.updateArrows();


### PR DESCRIPTION
Because of a condition in `sliderHandler()` checking if `slidesToShow <=
slides` we could never set the slide classes for a nav slider with this condition.

Had to split the `asNavFor()` method in to two parts, and set the slide classes
in the `slideHandler()` method when `options.asnavfor` is set and the
`slidesToShow <= slides` -- the other option (which I didn't want to tackle) was
to re-architect the whole `slideHandler` method.

bit hacky. but stable. This architecture should be reconsidered in 2.0, @kenwheeler 