### PR TITLE
Add missing documentation on adaptiveHeight

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -64,6 +64,7 @@ Example:
 Option | Type | Default | Description
 ------ | ---- | ------- | -----------
 accessibility | boolean | true | Enables tabbing and arrow key navigation
+adaptiveHeight | boolean | false | Adapts slider height to the current slide
 autoplay | boolean | false | Enables auto play of slides
 autoplaySpeed | int  | 3000 | Auto play change interval
 centerMode | boolean | false | Enables centered view with partial prev/next slides. Use with odd numbered slidesToShow counts.


### PR DESCRIPTION
I assumed this was missing since it's present on http://kenwheeler.github.io/slick/ but on in the README