### PR TITLE
End of carousel and resize with decimal value for slides to show

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slick-carousel",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "description": "the last carousel you'll ever need",
   "main": "slick/slick.js",
   "repository": {

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1542,7 +1542,7 @@
 
         var _ = this, currentSlide, firstVisible;
 
-        firstVisible = _.slideCount - _.options.slidesToShow;
+        firstVisible = Math.floor(_.slideCount - _.options.slidesToShow);
 
         // check that the new breakpoint can actually accept the
         // "current slide" as the current slide, otherwise we need


### PR DESCRIPTION
when slidesToShow is decimal value ie 3.5 we show 3 and 1/2 of a slide when we are at the end of the carousel and resize we get blank carousel. Also in some cases the order of the slides are not correct.

https://jsfiddle.net/earlyster/q1qznouw/321/