### PR TITLE
Correct issue with vertically centering arrow

### DIFF
--- a/slick/slick-theme.css
+++ b/slick/slick-theme.css
@@ -30,7 +30,6 @@
     width: 20px;
     height: 20px;
     padding: 0;
-    margin-top: -10px; /*lte IE 8*/
     -webkit-transform: translate(0, -50%);
     -ms-transform: translate(0, -50%);
     transform: translate(0, -50%);

--- a/slick/slick-theme.less
+++ b/slick/slick-theme.less
@@ -45,7 +45,6 @@
     background: transparent;
     color: transparent;
     top: 50%;
-    margin-top: -10px~'\9'; /*lte IE 8*/
     -webkit-transform: translate(0, -50%);
     -ms-transform: translate(0, -50%);
     transform: translate(0, -50%);

--- a/slick/slick-theme.scss
+++ b/slick/slick-theme.scss
@@ -67,7 +67,6 @@ $slick-opacity-not-active: 0.25 !default;
     background: transparent;
     color: transparent;
     top: 50%;
-    margin-top: -10px\9; /*lte IE 8*/
     -webkit-transform: translate(0, -50%);
     -ms-transform: translate(0, -50%);
     transform: translate(0, -50%);


### PR DESCRIPTION
A while ago I submitted a PR to make vertical centering of the arrows dynamic to the arrow height, using transform translate. Since IE8 doesn't support transforms, I thought I'd include the old fixed position offset using margin top, but use the \9 hack on the value to make it only apply to IE8.

I guess there was an issue with gulp, and a [PR to remove the \9 merged](https://github.com/kenwheeler/slick/pull/2006), causing the offset to register with all browsers, and making the arrows slightly off center.

The gulp issue is curious to me, because Bootstrap uses the \9 method, but I also appreciate that \9 is a clumsy trick, and my feeling is that if someone is using IE8 they can suffer a slightly off center arrow, in the interest of modernity and simplicity

As such, I removed the fallback in this PR.

