### PR TITLE
set max-width of image in slider

### DIFF
--- a/slick/slick.css
+++ b/slick/slick.css
@@ -87,6 +87,7 @@
 .slick-slide img
 {
     display: block;
+    max-width: 100%;
 }
 .slick-slide.slick-loading img
 {


### PR DESCRIPTION
- now at lower resolutions the picture will occupy 100% of the screen.