### PR TITLE
Add slick-dotted to slider when dots enable so spacing is triggered instead of default

### DIFF
--- a/slick/slick-theme.css
+++ b/slick/slick-theme.css
@@ -114,7 +114,7 @@
 }
 
 /* Dots */
-.slick-slider
+.slick-dotted.slick-slider
 {
     margin-bottom: 30px;
 }
@@ -122,12 +122,13 @@
 .slick-dots
 {
     position: absolute;
-    bottom: -45px;
+    bottom: -25px;
 
     display: block;
 
     width: 100%;
     padding: 0;
+    margin: 0;
 
     list-style: none;
 

--- a/slick/slick-theme.less
+++ b/slick/slick-theme.less
@@ -104,17 +104,18 @@
 
 /* Dots */
 
-.slick-slider {
+.slick-dotted .slick-slider {
     margin-bottom: 30px;
 }
 
 .slick-dots {
     position: absolute;
-    bottom: -45px;
+    bottom: -25px;
     list-style: none;
     display: block;
     text-align: center;
     padding: 0;
+    margin: 0;
     width: 100%;
     li {
         position: relative;

--- a/slick/slick-theme.scss
+++ b/slick/slick-theme.scss
@@ -125,17 +125,18 @@ $slick-opacity-not-active: 0.25 !default;
 
 /* Dots */
 
-.slick-slider {
+.slick-dotted.slick-slider {
     margin-bottom: 30px;
 }
 
 .slick-dots {
     position: absolute;
-    bottom: -45px;
+    bottom: -25px;
     list-style: none;
     display: block;
     text-align: center;
     padding: 0;
+    margin: 0;
     width: 100%;
     li {
         position: relative;

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -483,6 +483,8 @@
 
         if (_.options.dots === true && _.slideCount > _.options.slidesToShow) {
 
+            _.$slider.addClass('slick-dotted');
+        
             dot = $('<ul />').addClass(_.options.dotsClass);
 
             for (i = 0; i <= _.getDotCount(); i += 1) {
@@ -895,6 +897,7 @@
 
         _.$slider.removeClass('slick-slider');
         _.$slider.removeClass('slick-initialized');
+        _.$slider.removeClass('slick-dotted');
 
         _.unslicked = true;
 


### PR DESCRIPTION
This PR is in reference to #984. Basically the idea is that the spacing that's added to accommodate dots is still there even if `dots: false`

Wouldn't want to invite a deluge of messy class based styling, but I encounter this somewhat regularly; so, I wanted to submit it for your consideration.

Actually, as I dove into it a bit, I noticed the dots ul had some margin which seemed to make the positioning a bit convoluted, so I hollered at that too so offset essentially equals the height of the dots.

To test, toggle the dots on and off. Chapelle's Show gif to illustrate the spacing:
[SCSS version](http://codepen.io/leggomuhgreggo/pen/jWpMxb?editors=0010)
[LESS version](http://codepen.io/leggomuhgreggo/pen/JGBboa?editors=0010)
[CSS version](http://codepen.io/leggomuhgreggo/pen/eJjBJy?editors=0010)