### PR TITLE
Fix a bug after call slickRemove add slickAdd

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -443,8 +443,8 @@
 
             if( _.slideCount > _.options.slidesToShow ) {
 
-                _.$prevArrow.removeClass('slick-hidden').removeAttr('aria-hidden tabindex');
-                _.$nextArrow.removeClass('slick-hidden').removeAttr('aria-hidden tabindex');
+                _.$prevArrow.removeClass('slick-hidden').removeAttr('aria-hidden aria-disabled tabindex');
+                _.$nextArrow.removeClass('slick-hidden').removeAttr('aria-hidden aria-disabled tabindex');
 
                 if (_.htmlExpr.test(_.options.prevArrow)) {
                     _.$prevArrow.prependTo(_.options.appendArrows);


### PR DESCRIPTION
When use slickRemove to empty a carousel, *e.g while($slick.slick('slickRemove', 0));*, $prevArrow and $nextArrow will set its aria-disabled into true, so when use slickAdd add new items into the carousel, $prevArrow and $nextArrow need to be remove their aria-disabled attributes or set their aria-disabled attributes into false.