### PR TITLE
Prevent slide change in beforeChange event using preventDefault

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -81,8 +81,8 @@ arrows | boolean | true | Enable Next/Prev arrows
 appendArrows | string | $(element) | Change where the navigation arrows are attached (Selector, htmlString, Array, Element, jQuery object)
 appendDots | string | $(element) | Change where the navigation dots are attached (Selector, htmlString, Array, Element, jQuery object)
 mobileFirst | boolean | false | Responsive settings use mobile first calculation
-prevArrow | string (html|jQuery selector) | object (DOM node|jQuery object) | <button type="button" class="slick-prev">Previous</button> | Allows you to select a node or customize the HTML for the "Previous" arrow.
-nextArrow | string (html|jQuery selector) | object (DOM node|jQuery object) | <button type="button" class="slick-next">Next</button> | Allows you to select a node or customize the HTML for the "Next" arrow.
+prevArrow | string (html \| jQuery selector) \| object (DOM node \| jQuery object) | `<button type="button" class="slick-prev">Previous</button>` | Allows you to select a node or customize the HTML for the "Previous" arrow.
+nextArrow | string (html \| jQuery selector) \| object (DOM node \| jQuery object) | `<button type="button" class="slick-next">Next</button>` | Allows you to select a node or customize the HTML for the "Next" arrow.
 infinite | boolean | true | Infinite looping
 initialSlide | integer | 0 | Slide to start on
 lazyLoad | string | 'ondemand' | Accepts 'ondemand' or 'progressive' for lazy load technique. 'ondemand' will load the image as soon as you slide to it, 'progressive' loads one image after the other when the page loads.

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2313,10 +2313,6 @@
             return;
         }
 
-        if (sync === false) {
-            _.asNavFor(index);
-        }
-
         targetSlide = index;
         targetLeft = _.getLeft(targetSlide);
         slideLeft = _.getLeft(_.currentSlide);
@@ -2371,7 +2367,17 @@
 
         _.animating = true;
 
-        _.$slider.trigger('beforeChange', [_, _.currentSlide, animSlide]);
+        var beforeChangeEvent = jQuery.Event('beforeChange');
+        _.$slider.trigger(beforeChangeEvent, [_, _.currentSlide, animSlide]);
+
+        if(beforeChangeEvent.isDefaultPrevented()) {
+            _.animating = false;
+            return;
+        }
+
+        if (sync === false) {
+            _.asNavFor(index);
+        }
 
         oldSlide = _.currentSlide;
         _.currentSlide = animSlide;

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1487,7 +1487,7 @@
             }
         } else {
             rangeStart = _.options.infinite ? _.options.slidesToShow + _.currentSlide : _.currentSlide;
-            rangeEnd = rangeStart + _.options.slidesToShow;
+            rangeEnd = Math.ceil(rangeStart + _.options.slidesToShow);
             if (_.options.fade === true) {
                 if (rangeStart > 0) rangeStart--;
                 if (rangeEnd <= _.slideCount) rangeEnd++;

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2370,7 +2370,7 @@
         var beforeChangeEvent = jQuery.Event('beforeChange');
         _.$slider.trigger(beforeChangeEvent, [_, _.currentSlide, animSlide]);
 
-        if (beforeChangeEvent.defaultPrevented) {
+        if (beforeChangeEvent.isDefaultPrevented()) {
             _.animating = false;
             if (dontAnimate !== true) {
                 _.animateSlide(slideLeft, function() {

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2370,7 +2370,7 @@
         var beforeChangeEvent = jQuery.Event('beforeChange');
         _.$slider.trigger(beforeChangeEvent, [_, _.currentSlide, animSlide]);
 
-        if(beforeChangeEvent.isDefaultPrevented()) {
+        if(beforeChangeEvent.defaultPrevented) {
             _.animating = false;
             return;
         }

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1050,7 +1050,6 @@
         } else if (_.options.centerMode === true) {
             pagerQty = _.slideCount;
         } else {
-            counter = _.slideCount % _.options.slidesToShow == 0 ? counter : counter + 1;
             while (breakPoint < _.slideCount) {
                 ++pagerQty;
                 breakPoint = counter + _.options.slidesToScroll;

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2370,8 +2370,16 @@
         var beforeChangeEvent = jQuery.Event('beforeChange');
         _.$slider.trigger(beforeChangeEvent, [_, _.currentSlide, animSlide]);
 
-        if(beforeChangeEvent.defaultPrevented) {
+        if (beforeChangeEvent.defaultPrevented) {
             _.animating = false;
+            if (dontAnimate !== true) {
+                _.animateSlide(slideLeft, function() {
+                    _.postSlide(_.currentSlide);
+                });
+            } else {
+                _.postSlide(_.currentSlide);
+            }
+
             return;
         }
 


### PR DESCRIPTION
This pull request adds the ability to prevent a slide change using `event.preventDefault()` related to the closed pull request #1139 and tries to solve #1138.

I moved the synchronization of `asNavFor` sliders right after the before change event to also prevent the change of linked sliders.

Demo Fiddle: http://jsfiddle.net/cfoehrdes/2sc7fuo9/3/
