### PR TITLE
Revert "Update: Fix Issue #2035 - Extra dot when slide count was not divisibl…"

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1050,7 +1050,6 @@
         } else if (_.options.centerMode === true) {
             pagerQty = _.slideCount;
         } else {
-            counter = _.slideCount % _.options.slidesToShow == 0 ? counter : counter + 1;
             while (breakPoint < _.slideCount) {
                 ++pagerQty;
                 breakPoint = counter + _.options.slidesToScroll;


### PR DESCRIPTION
Reverts kenwheeler/slick#2038

Found a breaking change which would make an uneven slide un-accessible with even `slidesToScroll` and `slidesToShow` :(