### PR TITLE
Center even number of horizontal slides when centerMode is true

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1062,16 +1062,12 @@
         }
 
         if (_.options.centerMode === true && _.slideCount <= _.options.slidesToShow) {
-            if (_.options.rtl === true) {
-                _.slideOffset = ((_.slideWidth * -Math.floor(_.options.slidesToShow)) / 2) + ((_.slideWidth * _.slideCount) / 2);
-            } else {
-                _.slideOffset = ((_.slideWidth * Math.floor(_.options.slidesToShow)) / 2) - ((_.slideWidth * _.slideCount) / 2);
-            }
+             _.slideOffset = ((_.slideWidth * Math.floor(_.options.slidesToShow)) / 2) - ((_.slideWidth * _.slideCount) / 2);
         } else if (_.options.centerMode === true && _.options.infinite === true) {
-            _.slideOffset += _.slideWidth * Math.floor(_.options.slidesToShow / 2) - _.slideWidth;
+             _.slideOffset += _.slideWidth * Math.floor(_.options.slidesToShow / 2) - _.slideWidth;
         } else if (_.options.centerMode === true) {
-            _.slideOffset = 0;
-            _.slideOffset += _.slideWidth * Math.floor(_.options.slidesToShow / 2);
+             _.slideOffset = 0;
+             _.slideOffset += _.slideWidth * Math.floor(_.options.slidesToShow / 2);
         }
 
         if (_.options.vertical === false) {

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1062,12 +1062,12 @@
         }
 
         if (_.options.centerMode === true && _.slideCount <= _.options.slidesToShow) {
-             _.slideOffset = ((_.slideWidth * Math.floor(_.options.slidesToShow)) / 2) - ((_.slideWidth * _.slideCount) / 2);
+            _.slideOffset = ((_.slideWidth * Math.floor(_.options.slidesToShow)) / 2) - ((_.slideWidth * _.slideCount) / 2);
         } else if (_.options.centerMode === true && _.options.infinite === true) {
-             _.slideOffset += _.slideWidth * Math.floor(_.options.slidesToShow / 2) - _.slideWidth;
+            _.slideOffset += _.slideWidth * Math.floor(_.options.slidesToShow / 2) - _.slideWidth;
         } else if (_.options.centerMode === true) {
-             _.slideOffset = 0;
-             _.slideOffset += _.slideWidth * Math.floor(_.options.slidesToShow / 2);
+            _.slideOffset = 0;
+            _.slideOffset += _.slideWidth * Math.floor(_.options.slidesToShow / 2);
         }
 
         if (_.options.vertical === false) {

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1061,7 +1061,13 @@
             verticalOffset = 0;
         }
 
-        if (_.options.centerMode === true && _.options.infinite === true) {
+        if (_.options.centerMode === true && _.slideCount <= _.options.slidesToShow) {
+            if (_.options.rtl === true) {
+                _.slideOffset = ((_.slideWidth * -Math.floor(_.options.slidesToShow)) / 2) + ((_.slideWidth * _.slideCount) / 2);
+            } else {
+                _.slideOffset = ((_.slideWidth * Math.floor(_.options.slidesToShow)) / 2) - ((_.slideWidth * _.slideCount) / 2);
+            }
+        } else if (_.options.centerMode === true && _.options.infinite === true) {
             _.slideOffset += _.slideWidth * Math.floor(_.options.slidesToShow / 2) - _.slideWidth;
         } else if (_.options.centerMode === true) {
             _.slideOffset = 0;


### PR DESCRIPTION
Before: http://jsfiddle.net/o7nkhnow/2/ *edit* updated with correct use of `rtl`
After: http://jsfiddle.net/gy1jy44j/2/ *edit* updated with correct fix for `rtl`

This MR centers an even number of slides when `_.slideCount <= _.options.slidesToShow` for horizontal sliders. 

If you want me to test more options please let me know and I'll be happy to do so. 