### PR TITLE
Remove aria-required attribute in buttons.

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -52,7 +52,7 @@
                 centerPadding: '50px',
                 cssEase: 'ease',
                 customPaging: function(slider, i) {
-                    return $('<button type="button" data-role="none" role="button" aria-required="false" tabindex="0" />').text(i + 1);
+                    return $('<button type="button" data-role="none" role="button" tabindex="0" />').text(i + 1);
                 },
                 dots: false,
                 dotsClass: 'slick-dots',


### PR DESCRIPTION
This attribute causes accessibility test to fail as it is only valid for input tags.