### PR TITLE
Fix a typo and add syntax highlighting language

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,28 +15,28 @@ CDN hosted slick is a great way to get set up quick:
 
 In your ```<head>``` add:
 
-````
+```html
 <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/jquery.slick/1.5.9/slick.css"/>
 
-// Add the slick-theme.css if you want default styling
+<!-- Add the slick-theme.css if you want default styling -->
 <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/jquery.slick/1.5.9/slick-theme.css"/>
-````
+```
 
 Then, before your closing ```<body>``` tag add:
 
-```
+```html
 <script type="text/javascript" src="//cdn.jsdelivr.net/jquery.slick/1.5.9/slick.min.js"></script>
 ```
 
 #### Package Managers
 
-````
-//Bower
+```sh
+# Bower
 bower install --save slick-carousel
 
-//NPM
+# NPM
 npm install slick-carousel
-````
+```
 
 #### Contributing
 
@@ -48,7 +48,7 @@ In slick 1.5 you can now add settings using the data-slick attribute. You still 
 
 Example:
 
-```markup
+```html
 <div data-slick='{"slidesToShow": 4, "slidesToScroll": 4}'>
   <div><h3>1</h3></div>
   <div><h3>2</h3></div>
@@ -93,7 +93,7 @@ respondTo | string | 'window' | Width that responsive object responds to. Can be
 responsive | array | null | Array of objects [containing breakpoints and settings objects (see example)](#responsive-option-example). Enables settings at given `breakpoint`. Set `settings` to "unslick" instead of an object to disable slick at a given breakpoint.
 rows | int | 1 | Setting this to more than 1 initializes grid mode. Use slidesPerRow to set how many slides should be in each row.
 slide | string | '' | Slide element query
-slidesPerRow | int | 1 | With grid mode intialized via the rows option, this sets how many slides are in each grid row.
+slidesPerRow | int | 1 | With grid mode initialized via the rows option, this sets how many slides are in each grid row.
 slidesToShow | int | 1 | # of slides to show at a time
 slidesToScroll | int | 1 | # of slides to scroll at a time
 speed | int | 300 | Transition speed
@@ -114,9 +114,9 @@ zIndex | number | 1000 | Set the zIndex values for slides, useful for IE9 and lo
 The responsive option, and value, is quite unique and powerful.
 You can use it like so:
 
-```
+```javascript
 $(".slider").slick({
-  
+
   // normal options...
   infinite: false,
 
@@ -236,7 +236,7 @@ $(element).slick({
   speed: 500
 });
  ```
- 
+
 Change the speed with:
 
 ```javascript


### PR DESCRIPTION
`intialized` → `initialized`
Add syntax highlighting language to HTML, Shell and Javascript code blocks