### PR TITLE
Slick can be integrated into Rails asset pipeline using jquery-slick-…

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -36,6 +36,9 @@ bower install --save slick-carousel
 
 # NPM
 npm install slick-carousel
+
+# RubyGems (for Rails)
+gem install jquery-slick-rails
 ```
 
 #### Contributing


### PR DESCRIPTION
…rails gem. Fixes #283

Not sure if I added it to the correct section though.

The gem (library) https://rubygems.org/gems/jquery-slick-rails is used pretty extensively by Rails devs and I always keep it up-to-date.
