### PR TITLE
Add option for more fingers to be useable for swipe gesture

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -80,6 +80,7 @@ fade | boolean | false | Enables fade
 arrows | boolean | true | Enable Next/Prev arrows
 appendArrows | string | $(element) | Change where the navigation arrows are attached (Selector, htmlString, Array, Element, jQuery object)
 appendDots | string | $(element) | Change where the navigation dots are attached (Selector, htmlString, Array, Element, jQuery object)
+maxSlideyFingers | number | 1 | Change how many fingers can be used for a swipe gesture
 mobileFirst | boolean | false | Responsive settings use mobile first calculation
 prevArrow | string (html \| jQuery selector) \| object (DOM node \| jQuery object) | `<button type="button" class="slick-prev">Previous</button>` | Allows you to select a node or customize the HTML for the "Previous" arrow.
 nextArrow | string (html \| jQuery selector) \| object (DOM node \| jQuery object) | `<button type="button" class="slick-next">Next</button>` | Allows you to select a node or customize the HTML for the "Next" arrow.

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -64,6 +64,7 @@
                 infinite: true,
                 initialSlide: 0,
                 lazyLoad: 'ondemand',
+                maxSlideyFingers: 1,
                 mobileFirst: false,
                 pauseOnHover: true,
                 pauseOnFocus: true,
@@ -2654,7 +2655,7 @@
 
         touches = event.originalEvent !== undefined ? event.originalEvent.touches : null;
 
-        if (!_.dragging || touches && touches.length !== 1) {
+        if (!_.dragging || touches && (touches.length > _.options.maxSlideyFingers || touches.length < 1) ) {
             return false;
         }
 
@@ -2727,7 +2728,7 @@
 
         _.interrupted = true;
 
-        if (_.touchObject.fingerCount !== 1 || _.slideCount <= _.options.slidesToShow) {
+        if (_.touchObject.fingerCount > _.options.maxSlideyFingers || _.touchObject.fingerCount < 1 || _.slideCount <= _.options.slidesToShow) {
             _.touchObject = {};
             return false;
         }


### PR DESCRIPTION
There are some contexts where it would be helpful to treat a swipe with any number of fingers just like a single-finger swipe.

My particular use case is a digital signage application. Users won't be using the normal multi-touch gestures that one might reasonably expect in a browser (two-finger swipe for "BACK", for example). As such, it can be helpful to allow more than one finger to perform the swipe action.

This fix still assumes that the 0th finger in the touch events is the one to track for purposes of the swipe; it's just a way to let someone swipe with two fingers by "mistake", which is particularly helpful for large touch-enabled surfaces.