### PR TITLE
Fix #1871: Editing Row amounts for responsive 

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -556,7 +556,7 @@
         newSlides = document.createDocumentFragment();
         originalSlides = _.$slider.children();
 
-        if(_.options.rows > 1) {
+        if(_.options.rows >= 1) {
 
             slidesPerSection = _.options.slidesPerRow * _.options.rows;
             numOfSlides = Math.ceil(
@@ -811,7 +811,7 @@
 
         var _ = this, originalSlides;
 
-        if(_.options.rows > 1) {
+        if(_.options.rows >= 1) {
             originalSlides = _.$slides.children().children();
             originalSlides.removeAttr('style');
             _.$slider.empty().append(originalSlides);


### PR DESCRIPTION
Now with proper request documentation:

**Problem**: Breakpoint *rows* are not being change properly
**Before-Fix**: http://jsfiddle.net/falke88/fmo50w7n/269/
**After-Fix**: http://jsfiddle.net/falke88/fmo50w7n/267/
Now it is possible to let a slider with only one row to transform to a slider with more rows when hitting the breakpoint. Also its possible the other way around - starting with 3 rows and then on breakpoint falling back to one row only. 
The state before the fix only could change starting from two rows. It wasn't possible to change from 1 to 2 rows or from 2 to 1 row.

**Different options sets:**
http://jsfiddle.net/falke88/fmo50w7n/271/ - benchmarked with switching to 10 slides on breakpoint
http://jsfiddle.net/falke88/fmo50w7n/272/ - still buggin changing from 0 rows to 1 (but who starts with 0 rows anyway - mybe catch this situation with an Error ?)
http://jsfiddle.net/falke88/fmo50w7n/274/ - changing from 2 rows to 1 rows to 3 rows in two breakpoint steps (Not possible before fix: http://jsfiddle.net/falke88/fmo50w7n/275/ - the breakpoint with row : 1 is being skipped)
http://jsfiddle.net/falke88/fmo50w7n/276/ - same as above with different slidesToShow numbers

Greets and thanks for the guidance to proper pull requesting ;)

Charlie