### PR TITLE
Fixed an iOS Bug considering width

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -138,7 +138,7 @@
             _.transformType = null;
             _.transitionType = null;
             _.visibilityChange = 'visibilitychange';
-            _.windowWidth = 0;
+            _.windowWidth = $(window).width();
             _.windowTimer = null;
 
             dataSettings = $(element).data('slick') || {};


### PR DESCRIPTION
On iOS resize Events are triggered when scrolling the page. This means that the slick-slider will get into that part of code where it checks if the old window width (_.windowWidth) has delta with the new one. This also means that the first time scroll happens on iOS the resize will be triggered. 

Furthermore: When you open a scrollable layer and hide all the elements below, the surrounding container of the slick-slider will have no width and height but will try to recaculate based on the fact scrolling happened. This results in unwanted slider results.


If you do _not_ accept this fix or if you need _.windowWidth = 0 for any other reason please tell me and I can provide a different fix for this problem.