### PR TITLE
Fix #2236: slick-active classes get triggered falsely

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2248,7 +2248,9 @@
                 remainder = _.slideCount % _.options.slidesToShow;
                 indexOffset = _.options.infinite === true ? _.options.slidesToShow + index : index;
 
-                if (_.options.slidesToShow == _.options.slidesToScroll && (_.slideCount - index) < _.options.slidesToShow) {
+               // this query causes trouble with slides marked active, therefore removed
+               // if (_.options.slidesToShow == _.options.slidesToScroll && (_.slideCount - index) < _.options.slidesToShow)
+                if ((_.slideCount - index) < _.options.slidesToShow) {
 
                     allSlides
                         .slice(indexOffset - (_.options.slidesToShow - remainder), indexOffset + remainder)

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2248,8 +2248,6 @@
                 remainder = _.slideCount % _.options.slidesToShow;
                 indexOffset = _.options.infinite === true ? _.options.slidesToShow + index : index;
 
-               // this query causes trouble with slides marked active, therefore removed
-               // if (_.options.slidesToShow == _.options.slidesToScroll && (_.slideCount - index) < _.options.slidesToShow)
                 if ((_.slideCount - index) < _.options.slidesToShow) {
 
                     allSlides


### PR DESCRIPTION
Fixes #2236 

I just removed one condition which prevents the right setClasses method. Not sure what side effects it has though.

@kenwheeler can you explain what the condition `_.options.slidesToShow == _.options.slidesToScroll` is meant for? This is the reason why this if-section is skipped falsely in this fiddle: [http://jsfiddle.net/H66vv/25/](http://jsfiddle.net/H66vv/25/)

my config is:
{
        infinite: false,
        slidesToShow: 3,
        slidesToScroll: 1
}