### PR TITLE
set animating to false before triggering afterChange event

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1593,9 +1593,9 @@
 
         if( !_.unslicked ) {
 
-            _.$slider.trigger('afterChange', [_, index]);
-
             _.animating = false;
+
+            _.$slider.trigger('afterChange', [_, index]);
 
             _.setPosition();
 


### PR DESCRIPTION
Animating still set to true when afterChange event
Issue #2264 