### PR TITLE
Replaced protocol-relative URL with HTTPS protocol

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,15 +21,15 @@ to serve the files as close, and fast as possible to your users:
 
 Just add a link to the css file in your `<head>`:
 ```html
-<link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/jquery.slick/1.5.9/slick.css"/>
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/jquery.slick/1.5.9/slick.css"/>
 <!-- Add the slick-theme.css if you want default styling -->
-<link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/jquery.slick/1.5.9/slick-theme.css"/>
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/jquery.slick/1.5.9/slick-theme.css"/>
 ```
 
 Then, before your closing ```<body>``` tag add:
 
 ```html
-<script type="text/javascript" src="//cdn.jsdelivr.net/jquery.slick/1.5.9/slick.min.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/jquery.slick/1.5.9/slick.min.js"></script>
 ```
 
 #### Package Managers


### PR DESCRIPTION
It is no longer considered good practice to use protocol-relative URLs (http://www.paulirish.com/2010/the-protocol-relative-url/). So the CDN request should be made via HTTPs.
