### PR TITLE
Added  property "slick.isTriggeredAutomatically" in event handlers to…

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -140,6 +140,7 @@
             _.visibilityChange = 'visibilitychange';
             _.windowWidth = 0;
             _.windowTimer = null;
+            _.isTriggeredAutomatically = false;
 
             dataSettings = $(element).data('slick') || {};
 
@@ -395,6 +396,8 @@
 
         var _ = this;
 
+        _.isTriggeredAutomatically = false;
+
         if (_.autoPlayTimer) {
             clearInterval(_.autoPlayTimer);
         }
@@ -405,6 +408,8 @@
 
         var _ = this,
             slideTo = _.currentSlide + _.options.slidesToScroll;
+
+        _.isTriggeredAutomatically = true;
 
         if ( !_.paused && !_.interrupted && !_.focussed ) {
 


### PR DESCRIPTION
Hi! This PR refers to my issue https://github.com/kenwheeler/slick/issues/2212

Usage is the same as I described above

```
$('.my-slider').slick({
    autoplay: true,
    autoplaySpeed: 1000,
    dots: true
}).on('afterChange', function (event, slick, currentSlide) {
    if (!slick.isTriggeredAutomatically) {
        // slider was run by user, do something!
    }
});
```