### PR TITLE
if direction is vertical, stop dragging

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2676,6 +2676,9 @@
         swipeDirection = _.swipeDirection();
 
         if (swipeDirection === 'vertical') {
+            if (_.options.verticalSwiping === false) {
+              _.dragging = false;
+            }
             return;
         }
 


### PR DESCRIPTION

Hello.

If you are using this library , we pull request because there was hard to use points .

Fixes.

When the lateral swipe mode
When you page move the vertical scroll , Fixed would be moved next to the object of Slick a little bit of lateral movement of the finger .