### PR TITLE
Slick dots and arrows don't show, Unicode problem.

### DIFF
--- a/slick/slick-theme.css
+++ b/slick/slick-theme.css
@@ -1,4 +1,4 @@
-@charset 'UTF-8';
+@charset "UTF-8";
 /* Slider */
 .slick-loading .slick-list
 {


### PR DESCRIPTION
Master version. AngularJS, Grunt, Bower. 

In minify process dots and arrow don't show. @charset mut be with double quotes.