### PR TITLE
added "return" so it can be used in module style

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2893,4 +2893,6 @@
         return _;
     };
 
+    return Slick;
+
 }));


### PR DESCRIPTION
Please add the "return" so that the slider can not only be used as jQuery plugin. At the moment "module.exports" is to undefined.