### PR TITLE
Fix tab behavior for accessibility

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1278,9 +1278,6 @@
         var _ = this;
         _.$slides.add(_.$slideTrack.find('.slick-cloned')).attr({
             'aria-hidden': 'true',
-            'tabindex': '-1'
-        }).find('a, input, button, select').attr({
-            'tabindex': '-1'
         });
 
         _.$slideTrack.attr('role', 'listbox');
@@ -1393,6 +1390,7 @@
 
         if (_.options.accessibility === true) {
             _.$list.on('keydown.slick', _.keyHandler);
+            _.$list.on('focusin a, button, input, select', $.proxy(_.focusSlideHandler, _));
         }
 
         if (_.options.focusOnSelect === true) {
@@ -1449,6 +1447,15 @@
             }
         }
 
+    };
+
+    Slick.prototype.focusSlideHandler = function(event) {
+        event.preventDefault();
+        event.stopPropagation();
+        var _ = this,
+            slide = $(event.target).closest('.slick-slide'),
+            index = slide.data('slick-index');
+        _.slideHandler(index);
     };
 
     Slick.prototype.lazyLoad = function() {


### PR DESCRIPTION
Tab selection was not possible when tabbing
through an element that was outsideo of the
current view.

This changes the behavior, so that you can
tab through all the slides if they have an
element that can be focused (e.g. <a> link).

When you tab to a slide outside of the current
view, slick will automatically switch its
position so that the slide comes into view.

I'll try to make a jsfiddle that reproduces the issue.