### PR TITLE
Added "ariaPolite" options to enable/disable the aria-live attribute

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -39,6 +39,7 @@
 
             _.defaults = {
                 accessibility: true,
+                ariaPolite: true,
                 adaptiveHeight: false,
                 appendArrows: $(element),
                 appendDots: $(element),
@@ -501,7 +502,7 @@
 
     Slick.prototype.buildOut = function() {
 
-        var _ = this;
+        var _ = this, wrapperTemplate;
 
         _.$slides =
             _.$slider
@@ -522,8 +523,14 @@
             $('<div class="slick-track"/>').appendTo(_.$slider) :
             _.$slides.wrapAll('<div class="slick-track"/>').parent();
 
+        if(_.options.ariaPolite) {
+            wrapperTemplate = '<div aria-live="polite" class="slick-list"/>';
+        } else {
+            wrapperTemplate = '<div class="slick-list"/>'
+        }
+
         _.$list = _.$slideTrack.wrap(
-            '<div aria-live="polite" class="slick-list"/>').parent();
+            wrapperTemplate).parent();
         _.$slideTrack.css('opacity', 0);
 
         if (_.options.centerMode === true || _.options.swipeToSlide === true) {
@@ -1287,10 +1294,10 @@
 
         _.$slides.not(_.$slideTrack.find('.slick-cloned')).each(function(i) {
             $(this).attr('role', 'option');
-            
+
             //Evenly distribute aria-describedby tags through available dots.
             var describedBySlideId = _.options.centerMode ? i : Math.floor(i / _.options.slidesToShow);
-            
+
             if (_.options.dots === true) {
                 $(this).attr('aria-describedby', 'slick-slide' + _.instanceUid + describedBySlideId + '');
             }


### PR DESCRIPTION
On some page templates the aria-live="polite" attribute make the entire page not accesible with screen readers because it force the screen reader to read the slick content on changes and users could not focus on other page fragments.