### PR TITLE
A11y helpers

### DIFF
--- a/slick/slick-theme.css
+++ b/slick/slick-theme.css
@@ -38,7 +38,6 @@
 
     color: transparent;
     border: none;
-    outline: none;
     background: transparent;
 }
 .slick-prev:hover,
@@ -47,7 +46,6 @@
 .slick-next:focus
 {
     color: transparent;
-    outline: none;
     background: transparent;
 }
 .slick-prev:hover:before,
@@ -162,13 +160,7 @@
 
     color: transparent;
     border: 0;
-    outline: none;
     background: transparent;
-}
-.slick-dots li button:hover,
-.slick-dots li button:focus
-{
-    outline: none;
 }
 .slick-dots li button:hover:before,
 .slick-dots li button:focus:before

--- a/slick/slick-theme.less
+++ b/slick/slick-theme.less
@@ -50,9 +50,7 @@
     transform: translate(0, -50%);
     padding: 0;
     border: none;
-    outline: none;
     &:hover, &:focus {
-        outline: none;
         background: transparent;
         color: transparent;
         &:before {
@@ -131,14 +129,12 @@
             display: block;
             height: 20px;
             width: 20px;
-            outline: none;
             line-height: 0px;
             font-size: 0px;
             color: transparent;
             padding: 5px;
             cursor: pointer;
             &:hover, &:focus {
-                outline: none;
                 &:before {
                     opacity: @slick-opacity-on-hover;
                 }

--- a/slick/slick-theme.scss
+++ b/slick/slick-theme.scss
@@ -77,9 +77,7 @@ $slick-opacity-not-active: 0.25 !default;
     transform: translate(0, -50%);
     padding: 0;
     border: none;
-    outline: none;
     &:hover, &:focus {
-        outline: none;
         background: transparent;
         color: transparent;
         &:before {
@@ -157,14 +155,12 @@ $slick-opacity-not-active: 0.25 !default;
             display: block;
             height: 20px;
             width: 20px;
-            outline: none;
             line-height: 0px;
             font-size: 0px;
             color: transparent;
             padding: 5px;
             cursor: pointer;
             &:hover, &:focus {
-                outline: none;
                 &:before {
                     opacity: $slick-opacity-on-hover;
                 }

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -52,7 +52,7 @@
                 centerPadding: '50px',
                 cssEase: 'ease',
                 customPaging: function(slider, i) {
-                    return $('<button type="button" data-role="none" role="button" tabindex="0" />').text(i + 1);
+                    return $('<button type="button" data-role="none" role="button" tabindex="0" />').text('Slide ' + (i + 1));
                 },
                 dots: false,
                 dotsClass: 'slick-dots',
@@ -1011,7 +1011,9 @@
             .on('focus.slick blur.slick',
                 '*:not(.slick-arrow)', function(event) {
 
-            event.stopImmediatePropagation();
+            // stopImmediatePropagation kills the ability to
+            // check for focus inside the slider from external JS.
+            // event.stopImmediatePropagation();
             var $sf = $(this);
 
             setTimeout(function() {
@@ -1287,10 +1289,10 @@
 
         _.$slides.not(_.$slideTrack.find('.slick-cloned')).each(function(i) {
             $(this).attr('role', 'option');
-            
+
             //Evenly distribute aria-describedby tags through available dots.
             var describedBySlideId = _.options.centerMode ? i : Math.floor(i / _.options.slidesToShow);
-            
+
             if (_.options.dots === true) {
                 $(this).attr('aria-describedby', 'slick-slide' + _.instanceUid + describedBySlideId + '');
             }


### PR DESCRIPTION
- Remove `outline: none` on arrows/dots
- Comment out a `stopImmediatePropagation` as it interferes with custom focus work ([see this comment](https://github.com/kenwheeler/slick/commit/785d1698d157e13067b800ff902ff495d954670c#commitcomment-18434941))
- Change dot text to `Slide x` from simply a number