### PR TITLE
fix initialSlide behaviour for infinite and non infinite

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -145,7 +145,11 @@
 
             _.options = $.extend({}, _.defaults, settings, dataSettings);
 
-            _.currentSlide = _.options.initialSlide;
+            if (!_.options.infinite && _.options.initialSlide > 0) {
+                _.currentSlide = Math.floor(_.options.initialSlide / _.options.slidesToShow) * _.options.slidesToShow;
+            } else {
+                _.currentSlide = _.options.initialSlide;
+            }
 
             _.originalSettings = _.options;
 

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -145,7 +145,7 @@
 
             _.options = $.extend({}, _.defaults, settings, dataSettings);
 
-            if (!_.options.infinite && _.options.initialSlide > 0) {
+            if (!_.options.centerMode && _.options.initialSlide > 0) {
                 _.currentSlide = Math.floor(_.options.initialSlide / _.options.slidesToShow) * _.options.slidesToShow;
             } else {
                 _.currentSlide = _.options.initialSlide;


### PR DESCRIPTION
these two commits are where i settled on fixing two problems

1) arrows broke on non-infinite slicks with initialSlide as referenced by https://github.com/kenwheeler/slick/issues/2443
and demonstrated by http://jsfiddle.net/nnq25qft/5/

2) the default positioning and therefore first two attempts to scroll would be really weird on inifnite slicks with initialSlides. not sure if there was a bug report for it, but it was odd.
also demonstrated by http://jsfiddle.net/nnq25qft/5/

a fiddle of the corrected behaviours:
http://jsfiddle.net/xgu58fbp/2/