### PR TITLE
Added lazyLoad option 'anticipated' to preload {n} images

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -64,7 +64,6 @@
                 infinite: true,
                 initialSlide: 0,
                 lazyLoad: 'ondemand',
-                preLoad: false,
                 mobileFirst: false,
                 pauseOnHover: true,
                 pauseOnFocus: true,
@@ -1514,38 +1513,22 @@
         }
 
         loadRange = _.$slider.find('.slick-slide').slice(rangeStart, rangeEnd);
-        loadImages(loadRange);
 
-        if (_.options.preLoad === true) {
-            var preLoadNextRangeStart, preLoadNextRangeEnd, preLoadNextRange,
-                    preLoadPrevRangeStart, preLoadPrevPrevRangeEnd, preLoadPrevRange;
+        if (_.options.lazyLoad === 'anticipated') {
+            var prevSlide = rangeStart - 1,
+                nextSlide = rangeEnd,
+                $slides = _.$slider.find('.slick-slide');
 
-            var realSlides = _.$slider.find('.slick-slide:not(.slick-cloned)').get();
-
-            // Pre-loading next set of images
-            preLoadNextRangeStart = --rangeEnd < _.slideCount ? rangeEnd : 0;
-            preLoadNextRangeEnd = preLoadNextRangeStart + _.options.slidesToShow;
-
-            if (preLoadNextRangeEnd >= _.slideCount) {
-                preLoadNextRange = realSlides.slice(preLoadNextRangeStart)
-                        .concat(realSlides.slice(0, preLoadNextRangeEnd - _.slideCount));
-            } else {
-                preLoadNextRange = realSlides.slice(preLoadNextRangeStart, preLoadNextRangeEnd);
+            for (var i = 0; i < _.options.slidesToScroll; i++) {
+                if (prevSlide < 0) prevSlide = _.slideCount - 1;
+                loadRange = loadRange.add($slides.eq(prevSlide));
+                loadRange = loadRange.add($slides.eq(nextSlide));
+                prevSlide--;
+                nextSlide++;
             }
-            loadImages(preLoadNextRange);
-
-            // Pre-loading prev set of images
-            preLoadPrevPrevRangeEnd = --rangeStart > 0 ? rangeStart : _.slideCount;
-            preLoadPrevRangeStart = preLoadPrevPrevRangeEnd - _.options.slidesToShow;
-
-            if (preLoadPrevRangeStart < 0) {
-                preLoadPrevRange = realSlides.slice(0, preLoadPrevPrevRangeEnd).reverse()
-                        .concat(realSlides.slice(_.slideCount + preLoadPrevRangeStart).reverse);
-            } else {
-                preLoadPrevRange = realSlides.slice(preLoadPrevRangeStart, preLoadPrevPrevRangeEnd);
-            }
-            loadImages(preLoadPrevRange);
         }
+
+        loadImages(loadRange);
 
         if (_.slideCount <= _.options.slidesToShow) {
             cloneRange = _.$slider.find('.slick-slide');
@@ -2304,10 +2287,9 @@
 
         }
 
-        if (_.options.lazyLoad === 'ondemand') {
+        if (_.options.lazyLoad === 'ondemand' || _.options.lazyLoad === 'anticipated') {
             _.lazyLoad();
         }
-
     };
 
     Slick.prototype.setupInfinite = function() {

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -64,6 +64,7 @@
                 infinite: true,
                 initialSlide: 0,
                 lazyLoad: 'ondemand',
+                preLoad: false,
                 mobileFirst: false,
                 pauseOnHover: true,
                 pauseOnFocus: true,
@@ -847,7 +848,6 @@
             _.$dots.remove();
         }
 
-
         if ( _.$prevArrow && _.$prevArrow.length ) {
 
             _.$prevArrow
@@ -870,7 +870,6 @@
             if ( _.htmlExpr.test( _.options.nextArrow )) {
                 _.$nextArrow.remove();
             }
-
         }
 
 
@@ -1287,10 +1286,10 @@
 
         _.$slides.not(_.$slideTrack.find('.slick-cloned')).each(function(i) {
             $(this).attr('role', 'option');
-            
+
             //Evenly distribute aria-describedby tags through available dots.
             var describedBySlideId = _.options.centerMode ? i : Math.floor(i / _.options.slidesToShow);
-            
+
             if (_.options.dots === true) {
                 $(this).attr('aria-describedby', 'slick-slide' + _.instanceUid + describedBySlideId + '');
             }
@@ -1516,6 +1515,37 @@
 
         loadRange = _.$slider.find('.slick-slide').slice(rangeStart, rangeEnd);
         loadImages(loadRange);
+
+        if (_.options.preLoad === true) {
+            var preLoadNextRangeStart, preLoadNextRangeEnd, preLoadNextRange,
+                    preLoadPrevRangeStart, preLoadPrevPrevRangeEnd, preLoadPrevRange;
+
+            var realSlides = _.$slider.find('.slick-slide:not(.slick-cloned)').get();
+
+            // Pre-loading next set of images
+            preLoadNextRangeStart = --rangeEnd < _.slideCount ? rangeEnd : 0;
+            preLoadNextRangeEnd = preLoadNextRangeStart + _.options.slidesToShow;
+
+            if (preLoadNextRangeEnd >= _.slideCount) {
+                preLoadNextRange = realSlides.slice(preLoadNextRangeStart)
+                        .concat(realSlides.slice(0, preLoadNextRangeEnd - _.slideCount));
+            } else {
+                preLoadNextRange = realSlides.slice(preLoadNextRangeStart, preLoadNextRangeEnd);
+            }
+            loadImages(preLoadNextRange);
+
+            // Pre-loading prev set of images
+            preLoadPrevPrevRangeEnd = --rangeStart > 0 ? rangeStart : _.slideCount;
+            preLoadPrevRangeStart = preLoadPrevPrevRangeEnd - _.options.slidesToShow;
+
+            if (preLoadPrevRangeStart < 0) {
+                preLoadPrevRange = realSlides.slice(0, preLoadPrevPrevRangeEnd).reverse()
+                        .concat(realSlides.slice(_.slideCount + preLoadPrevRangeStart).reverse);
+            } else {
+                preLoadPrevRange = realSlides.slice(preLoadPrevRangeStart, preLoadPrevPrevRangeEnd);
+            }
+            loadImages(preLoadPrevRange);
+        }
 
         if (_.slideCount <= _.options.slidesToShow) {
             cloneRange = _.$slider.find('.slick-slide');


### PR DESCRIPTION
### Description
So that the user experience is better, the images should be loaded on demand, but anticipated, meaning, that the slider will always be one step ahead of the user, by pre-loading the 1 next and 1 previous image so that the loading is seamless, without ever making the user aware that the image was loading. On the other hand, this represents an improvement over loading all the images progressively, as the amount of data to load might not be worth causing also a poor experience, specially on mobile devices with slow connections.

### Demo

http://jsfiddle.net/zeL1kmo3/12/

### Process

There are a few edge cases in which lazyLoad === 'anticipated' might not work as expected, they are rooted on the nature of the current implementation, some bugs and limitations:

1. If slidesToScroll > 1, going from index 0 to -2 and index 8 to 10 only contains one `cloned` item, so scrolling 2 shows an empty image during the animation This can be see in line https://github.com/kenwheeler/slick/blob/master/slick/slick.js#L2034, as `slidesToShow` is used where `slidesToScroll` should be the amount of clones to set-up.

2. If slidesToScroll > 1 and the number of images is an odd number. Similar problem to 1.

3. When `fade == true`, the rangeEnd seems to be +1 count too much, this is either related to another bug or an implementation feature I am not aware of.

Credits to @AlaaSarhan for his collaboration bringing this feature to life.