### PR TITLE
Accessibility improvements

### DIFF
--- a/slick/slick-theme.css
+++ b/slick/slick-theme.css
@@ -38,7 +38,6 @@
 
     color: transparent;
     border: none;
-    outline: none;
     background: transparent;
 }
 .slick-prev:hover,
@@ -47,7 +46,6 @@
 .slick-next:focus
 {
     color: transparent;
-    outline: none;
     background: transparent;
 }
 .slick-prev:hover:before,
@@ -162,13 +160,7 @@
 
     color: transparent;
     border: 0;
-    outline: none;
     background: transparent;
-}
-.slick-dots li button:hover,
-.slick-dots li button:focus
-{
-    outline: none;
 }
 .slick-dots li button:hover:before,
 .slick-dots li button:focus:before

--- a/slick/slick-theme.less
+++ b/slick/slick-theme.less
@@ -50,9 +50,7 @@
     transform: translate(0, -50%);
     padding: 0;
     border: none;
-    outline: none;
     &:hover, &:focus {
-        outline: none;
         background: transparent;
         color: transparent;
         &:before {
@@ -131,14 +129,12 @@
             display: block;
             height: 20px;
             width: 20px;
-            outline: none;
             line-height: 0px;
             font-size: 0px;
             color: transparent;
             padding: 5px;
             cursor: pointer;
             &:hover, &:focus {
-                outline: none;
                 &:before {
                     opacity: @slick-opacity-on-hover;
                 }

--- a/slick/slick-theme.scss
+++ b/slick/slick-theme.scss
@@ -77,9 +77,7 @@ $slick-opacity-not-active: 0.25 !default;
     transform: translate(0, -50%);
     padding: 0;
     border: none;
-    outline: none;
     &:hover, &:focus {
-        outline: none;
         background: transparent;
         color: transparent;
         &:before {
@@ -157,14 +155,12 @@ $slick-opacity-not-active: 0.25 !default;
             display: block;
             height: 20px;
             width: 20px;
-            outline: none;
             line-height: 0px;
             font-size: 0px;
             color: transparent;
             padding: 5px;
             cursor: pointer;
             &:hover, &:focus {
-                outline: none;
                 &:before {
                     opacity: $slick-opacity-on-hover;
                 }

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -44,15 +44,15 @@
                 appendDots: $(element),
                 arrows: true,
                 asNavFor: null,
-                prevArrow: '<button type="button" data-role="none" class="slick-prev" aria-label="Previous" tabindex="0" role="button">Previous</button>',
-                nextArrow: '<button type="button" data-role="none" class="slick-next" aria-label="Next" tabindex="0" role="button">Next</button>',
+                prevArrow: '<button type="button" data-role="none" class="slick-prev" aria-label="Previous" tabindex="0" role="button">Previous slide</button>',
+                nextArrow: '<button type="button" data-role="none" class="slick-next" aria-label="Next" tabindex="0" role="button">Next slide</button>',
                 autoplay: false,
                 autoplaySpeed: 3000,
                 centerMode: false,
                 centerPadding: '50px',
                 cssEase: 'ease',
                 customPaging: function(slider, i) {
-                    return $('<button type="button" data-role="none" role="button" tabindex="0" />').text(i + 1);
+                    return $('<button type="button" data-role="none" role="button" tabindex="0" />').text('Slide ' + i + 1);
                 },
                 dots: false,
                 dotsClass: 'slick-dots',
@@ -1287,10 +1287,10 @@
 
         _.$slides.not(_.$slideTrack.find('.slick-cloned')).each(function(i) {
             $(this).attr('role', 'option');
-            
+
             //Evenly distribute aria-describedby tags through available dots.
             var describedBySlideId = _.options.centerMode ? i : Math.floor(i / _.options.slidesToShow);
-            
+
             if (_.options.dots === true) {
                 $(this).attr('aria-describedby', 'slick-slide' + _.instanceUid + describedBySlideId + '');
             }


### PR DESCRIPTION
Improves the overall accessibility of the slideshow in a few ways.
### [Demo](http://codepen.io/cshold/full/PzXGxG)

Each feature is split up by commit:
### 1. Remove `outline: none` on arrows and buttons

Removing this appeases the visual state of the slider but [ignores accessibility](http://www.outlinenone.com/). @leggomuhgreggo mentions a fix is to remove from the production styles if it's an issue, but I'd argue this is the best slider on the market and should make the proper decisions out of the gate — including accessibility.
### 2. Update the labels on arrows and dots

Currently the arrows say "Next" and "Previous". I've updated to "Next slide" and "Previous slide" to each of of them so it's more obvious what is happening when the buttons is pressed. Similarly, the dots used to be labeled with a number corresponding to their index. The new labels will say "Slide 1", "Slide 2", etc.
### 3. Updated role and aria attributes

[aXe Chrome plugin](https://chrome.google.com/webstore/detail/axe/lhdoppojpmngadmnindnejefpokejbdd) helps debug accessibility issues and shows a few on the current implementation:
- ARIA attribute is not allowed: `aria-selected="true"` on dots
  - This is because dots are currently `role="presentation"`. Changing them to `tab` fixes this (see below)
- Required ARIA child role not present: tab
  - The dot container is `role="tablist"` so the children need to be `role="tab"` (not `presentation`)
- Invalid ARIA attribute value: aria-controls="navigation00"
  - Only an error because `aria-controls` needs to have a matching `id` on the slide container. Fixed by:
    - Change `navigation00` to `slickSlide00` for dots `aria-controls`
    - Add `id="slickSlide00"` to the slide container (not cloned versions)
    - Change `aria-describedby` to `aria-labelledby` as it is the recommended use for `role="tablist"`. [See this demo](http://accessibility.athena-ict.com/aria/examples/tabpanel2.shtml)
- No need for `role="listbox"` on the slide track now that `tablist` is used properly
- Remove JS adding `role="button"` on dots since it's already in `_.defaults.customPaging`
- Remove JS adding `role="toolbar"` to the closest div after the dot container as it doesn't actually do anything
- Remove `aria-hidden` from dots. They should always be accessible by keyboard/screen reader.

Lastly, slightly reorganized the `ADA` functions as well. Now `initADA` is only called once on `init`, then on `postSlide` use a new function called `updateADA`. This reduces the amount of `initADA` JS running after each slide transition.

@kenwheeler 
cc @stevebosworth @m-ux
