### PR TITLE
Fixes #2490: Faulty behaviour of filter function when used on nested sliders 

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2771,7 +2771,7 @@
 
         var _ = this;
 
-        $('.slick-cloned', _.$slider).remove();
+        _.$slideTrack.children('.slick-cloned').remove();
 
         if (_.$dots) {
             _.$dots.remove();

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -188,7 +188,7 @@
     Slick.prototype.activateADA = function() {
         var _ = this;
 
-        _.$slideTrack.find('.slick-active').attr({
+        _.$slideTrack.children('.slick-active').attr({
             'aria-hidden': 'false'
         }).find('a, input, button, select').attr({
             'tabindex': '0'
@@ -1206,7 +1206,7 @@
         centerOffset = _.options.centerMode === true ? _.slideWidth * Math.floor(_.options.slidesToShow / 2) : 0;
 
         if (_.options.swipeToSlide === true) {
-            _.$slideTrack.find('.slick-slide').each(function(index, slide) {
+            _.$slideTrack.children('.slick-slide').each(function(index, slide) {
                 if (slide.offsetLeft - centerOffset + ($(slide).outerWidth() / 2) > (_.swipeLeft * -1)) {
                     swipedSlide = slide;
                     return false;
@@ -1276,7 +1276,7 @@
 
     Slick.prototype.initADA = function() {
         var _ = this;
-        _.$slides.add(_.$slideTrack.find('.slick-cloned')).attr({
+        _.$slides.add(_.$slideTrack.children('.slick-cloned')).attr({
             'aria-hidden': 'true',
             'tabindex': '-1'
         }).find('a, input, button, select').attr({
@@ -1285,12 +1285,12 @@
 
         _.$slideTrack.attr('role', 'listbox');
 
-        _.$slides.not(_.$slideTrack.find('.slick-cloned')).each(function(i) {
+        _.$slides.not(_.$slideTrack.children('.slick-cloned')).each(function(i) {
             $(this).attr('role', 'option');
-            
+
             //Evenly distribute aria-describedby tags through available dots.
             var describedBySlideId = _.options.centerMode ? i : Math.floor(i / _.options.slidesToShow);
-            
+
             if (_.options.dots === true) {
                 $(this).attr('aria-describedby', 'slick-slide' + _.instanceUid + describedBySlideId + '');
             }
@@ -1514,18 +1514,18 @@
             }
         }
 
-        loadRange = _.$slider.find('.slick-slide').slice(rangeStart, rangeEnd);
+        loadRange = _.$slideTrack.children('.slick-slide').slice(rangeStart, rangeEnd);
         loadImages(loadRange);
 
         if (_.slideCount <= _.options.slidesToShow) {
-            cloneRange = _.$slider.find('.slick-slide');
+            cloneRange = _.$slideTrack.children('.slick-slide');
             loadImages(cloneRange);
         } else
         if (_.currentSlide >= _.slideCount - _.options.slidesToShow) {
-            cloneRange = _.$slider.find('.slick-cloned').slice(0, _.options.slidesToShow);
+            cloneRange = _.$slideTrack.children('.slick-cloned').slice(0, _.options.slidesToShow);
             loadImages(cloneRange);
         } else if (_.currentSlide === 0) {
-            cloneRange = _.$slider.find('.slick-cloned').slice(_.options.slidesToShow * -1);
+            cloneRange = _.$slideTrack.children('.slick-cloned').slice(_.options.slidesToShow * -1);
             loadImages(cloneRange);
         }
 
@@ -2182,8 +2182,8 @@
         var _ = this,
             centerOffset, allSlides, indexOffset, remainder;
 
-        allSlides = _.$slider
-            .find('.slick-slide')
+        allSlides = _.$slideTrack
+            .children('.slick-slide')
             .removeClass('slick-active slick-center slick-current')
             .attr('aria-hidden', 'true');
 
@@ -2314,7 +2314,7 @@
                         .attr('data-slick-index', slideIndex + _.slideCount)
                         .appendTo(_.$slideTrack).addClass('slick-cloned');
                 }
-                _.$slideTrack.find('.slick-cloned').find('[id]').each(function() {
+                _.$slideTrack.children('.slick-cloned').find('[id]').each(function() {
                     $(this).attr('id', '');
                 });
 


### PR DESCRIPTION
This fixes issue #2490.

When calling the filter function on nested sliders, it removes the infinite clone slides of the sub-sliders without recreating them. The fix makes sure that the unload function (which executed within the filter function) only removes the direct clone-slide-children of the given slider, not the clones of the sub-sliders. 

It also implements Pull Request #1846 for better general handling of nested sliders.

Original JsFiddle: https://jsfiddle.net/yg0c01zg/3/
Fixed JsFiddle: https://jsfiddle.net/yg0c01zg/4/ 