### PR TITLE
Reindex slides on Filter/Unfilter to prevent duplicate index entries

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -994,9 +994,14 @@
 
             _.$slideTrack.children(this.options.slide).detach();
 
+            var newIndex = 0;
             _.$slidesCache.filter(filter).each(function(index){
+                if ($(this).attr('data-slick-index') == _.currentSlide) {
+                    newIndex = index;
+                }
                 $(this).attr('data-slick-index', index);
             }).appendTo(_.$slideTrack);
+            _.currentSlide = newIndex;
 
             _.reinit();
 
@@ -2761,10 +2766,14 @@
 
             _.$slideTrack.children(this.options.slide).detach();
 
-            //_.$slidesCache.appendTo(_.$slideTrack);
+            var newIndex = 0;
             _.$slidesCache.each(function(index){
+                if ($(this).attr('data-slick-index') == _.currentSlide) {
+                    newIndex = index;
+                }
                 $(this).attr('data-slick-index', index);
             }).appendTo(_.$slideTrack);
+            _.currentSlide = newIndex;
 
             _.reinit();
 

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2761,7 +2761,10 @@
 
             _.$slideTrack.children(this.options.slide).detach();
 
-            _.$slidesCache.appendTo(_.$slideTrack);
+            //_.$slidesCache.appendTo(_.$slideTrack);
+            _.$slidesCache.each(function(index){
+                $(this).attr('data-slick-index', index);
+            }).appendTo(_.$slideTrack);
 
             _.reinit();
 

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -994,7 +994,9 @@
 
             _.$slideTrack.children(this.options.slide).detach();
 
-            _.$slidesCache.filter(filter).appendTo(_.$slideTrack);
+            _.$slidesCache.filter(filter).each(function(index){
+                $(this).attr('data-slick-index', index);
+            }).appendTo(_.$slideTrack);
 
             _.reinit();
 
@@ -1287,10 +1289,10 @@
 
         _.$slides.not(_.$slideTrack.find('.slick-cloned')).each(function(i) {
             $(this).attr('role', 'option');
-            
+
             //Evenly distribute aria-describedby tags through available dots.
             var describedBySlideId = _.options.centerMode ? i : Math.floor(i / _.options.slidesToShow);
-            
+
             if (_.options.dots === true) {
                 $(this).attr('aria-describedby', 'slick-slide' + _.instanceUid + describedBySlideId + '');
             }


### PR DESCRIPTION
When a slider is filtered/unfiltered, the slider-clones for infinite scrolling are always created anew, with the length of the now filtered array in mind. But the slider-elements themselves are not reindexed, wich can lead to duplicate index-entries. 

For example, the following indexes

- -1 (clone)
- 0
- 1
- 2
- 3
- 4 (clone)

will become this after filtering indexes 0 and 3:

- -1 (clone, newly indexed)
- 1
- 2
- 2 (clone, newly indexed)

Duplicate index entries can lead to problems with using the slider. In the fiddle https://jsfiddle.net/4hfa0gw5/4/ the current slide should always be shown in red in the slider-navigation below. If you move to slider "4. Nature" and click on "Only eatable things" to filter the slides, the slider navigation highlights Slider 3, but Slider 2 is shown. If you look into the DOM, it is actually the cloned slide at the end of the list that is shown, because it has the same index as Slider 3 (see above). 

By clicking further through the slider with the next button, the slider itself will work properly, but because of the mixed up indexes, the Slider-Navigation will display Slide 2 as active when Slide 3 is shown and nothing as active when Slide 2 is shown. 

The provided fix reindexes every slider item when filtered while also generating a new currentIndex value, so that the filtered indexes from above look like this: 

- -1 (cloned)
- 0 (formerly 1)
- 1 (formerly 2)
- 2 (cloned)

Working example here: https://jsfiddle.net/yop7xp57/3/
