### PR TITLE
[fix] https://github.com/kenwheeler/slick/issues/1252

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2568,7 +2568,7 @@
             _.$slider.trigger('edge', [_, _.swipeDirection() ]);
         }
 
-        if ( _.touchObject.swipeLength >= _.touchObject.minSwipe && (_.swipeDirection() == 'left' || _.swipeDirection() == 'right') ) {
+        if ( _.touchObject.swipeLength >= _.touchObject.minSwipe ) {
 
             direction = _.swipeDirection();
 

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -104,6 +104,7 @@
                 loadIndex: 0,
                 $nextArrow: null,
                 $prevArrow: null,
+                scrolling: false,
                 slideCount: null,
                 slideWidth: null,
                 $slideTrack: null,
@@ -111,6 +112,7 @@
                 sliding: false,
                 slideOffset: 0,
                 swipeLeft: null,
+                swiping: false,
                 $list: null,
                 touchObject: {},
                 transformsEnabled: false,
@@ -1289,10 +1291,10 @@
 
         _.$slides.not(_.$slideTrack.find('.slick-cloned')).each(function(i) {
             $(this).attr('role', 'option');
-            
+
             //Evenly distribute aria-describedby tags through available dots.
             var describedBySlideId = _.options.centerMode ? i : Math.floor(i / _.options.slidesToShow);
-            
+
             if (_.options.dots === true) {
                 $(this).attr('aria-describedby', 'slick-slide' + _.instanceUid + describedBySlideId + '');
             }
@@ -2548,6 +2550,13 @@
             direction;
 
         _.dragging = false;
+        _.swiping = false;
+
+        if (_.scrolling) {
+            _.scrolling = false;
+            return false;
+        }
+
         _.interrupted = false;
         _.shouldClick = ( _.touchObject.swipeLength > 10 ) ? false : true;
 
@@ -2559,7 +2568,7 @@
             _.$slider.trigger('edge', [_, _.swipeDirection() ]);
         }
 
-        if ( _.touchObject.swipeLength >= _.touchObject.minSwipe ) {
+        if ( _.touchObject.swipeLength >= _.touchObject.minSwipe && (_.swipeDirection() == 'left' || _.swipeDirection() == 'right') ) {
 
             direction = _.swipeDirection();
 
@@ -2658,11 +2667,11 @@
 
         var _ = this,
             edgeWasHit = false,
-            curLeft, swipeDirection, swipeLength, positionOffset, touches;
+            curLeft, swipeDirection, swipeLength, positionOffset, touches, verticalSwipeLength;
 
         touches = event.originalEvent !== undefined ? event.originalEvent.touches : null;
 
-        if (!_.dragging || touches && touches.length !== 1) {
+        if (!_.dragging || _.scrolling || touches && touches.length !== 1) {
             return false;
         }
 
@@ -2674,18 +2683,22 @@
         _.touchObject.swipeLength = Math.round(Math.sqrt(
             Math.pow(_.touchObject.curX - _.touchObject.startX, 2)));
 
+        verticalSwipeLength = Math.round(Math.sqrt(
+            Math.pow(_.touchObject.curY - _.touchObject.startY, 2)));
+
+        if (!_.options.verticalSwiping && !_.swiping && verticalSwipeLength > 4) {
+            _.scrolling = true;
+            return false;
+        }
+
         if (_.options.verticalSwiping === true) {
-            _.touchObject.swipeLength = Math.round(Math.sqrt(
-                Math.pow(_.touchObject.curY - _.touchObject.startY, 2)));
+            _.touchObject.swipeLength = verticalSwipeLength;
         }
 
         swipeDirection = _.swipeDirection();
 
-        if (swipeDirection === 'vertical') {
-            return;
-        }
-
         if (event.originalEvent !== undefined && _.touchObject.swipeLength > 4) {
+            _.swiping = true;
             event.preventDefault();
         }
 


### PR DESCRIPTION
## Description

This PR fixes the problem of carousel sliding while drag-scrolling vertically on a touch device. 
When the user scroll down and then swipe to the left or the right, the carousel swipes to left and right while scrolling which is quite annoying.
It's possible to see a video of the problem [here](https://app.box.com/s/778ipwoe0i1t474hla2lmf44b3j88lvk) and you can find the github issue [here](https://github.com/kenwheeler/slick/issues/1252)
### Demo

[Without the fix](http://jsfiddle.net/cvymm987/3/)
[With the fix](http://jsfiddle.net/jfex0dbh/1/)
### Note

You need to test these demos on touch devices
## Credits

All the credits goes to @levymetal. Thank you for the code to fix this issue.
