### PR TITLE
Add semicolon at start

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -15,7 +15,7 @@
 
  */
 /* global window, document, define, jQuery, setInterval, clearInterval */
-(function(factory) {
+;(function(factory) {
     'use strict';
     if (typeof define === 'function' && define.amd) {
         define(['jquery'], factory);


### PR DESCRIPTION
A good practice when working with multiple JS files is to add a single semicolon at the very beginning of each file to terminate any preceding malformed logic.
