### PR TITLE
add support for multiple asNavFor selectors

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2446,13 +2446,17 @@
 
         _.setSlideClasses(_.currentSlide);
 
-        if ( _.options.asNavFor ) {
+        if (_.options.asNavFor) {
 
             navTarget = _.getNavTarget();
-            navTarget = navTarget.slick('getSlick');
 
-            if ( navTarget.slideCount <= navTarget.options.slidesToShow ) {
-                navTarget.setSlideClasses(_.currentSlide);
+            if (navTarget !== null && typeof navTarget === 'object') {
+                navTarget.each(function () {
+                    var navTarget = $(this).slick('getSlick');
+                    if (navTarget.slideCount <= navTarget.options.slidesToShow) {
+                        navTarget.setSlideClasses(_.currentSlide);
+                    }
+                });
             }
 
         }


### PR DESCRIPTION
When set multiple selectors on the "asNavFor" setting, there's a bug "Uncaught TypeError: Cannot read property 'getSlick' of undefined". The error occurs on this code snippet:
`if (_.options.asNavFor) {
            navTarget = _.getNavTarget();
            navTarget = navTarget.slick('getSlick');

            if (navTarget.slideCount <= navTarget.options.slidesToShow) {
                navTarget.setSlideClasses(_.currentSlide);
            }
        }`

This is fixed by following the same approach as in " Slick.prototype.asNavFor":
`if (_.options.asNavFor) {
            navTarget = _.getNavTarget();
            if (navTarget !== null && typeof navTarget === 'object') {
                navTarget.each(function () {
                    var navTarget = $(this).slick('getSlick');
                    if (navTarget.slideCount <= navTarget.options.slidesToShow) {
                        navTarget.setSlideClasses(_.currentSlide);
                    }
                });
            }
        }`