### PR TITLE
Fix less comment syntax

### DIFF
--- a/slick/slick-theme.less
+++ b/slick/slick-theme.less
@@ -1,6 +1,6 @@
 @charset "UTF-8";
 
-// Default Variables
+/* Default Variables */
 
 @slick-font-path: "./fonts/";
 @slick-font-family: "slick";


### PR DESCRIPTION
single line comment `// xxx` is a valid (official valid) syntax.
better to change to normal `/* xxx */` comment syntax.

p.s.  processor like `postcss` doesn't support the single line comment originally.
