### PR TITLE
Update bower.json to only declare one main file per filetype

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,8 +2,6 @@
     "name": "slick-carousel",
     "main": [
         "slick/slick.js",
-        "slick/slick.css",
-        "slick/slick.less",
         "slick/slick.scss"
     ],
     "version": "1.6.0",


### PR DESCRIPTION
The `bower.json` file specification now explicitly states, that the `main` field should only contain the main entry points of the package, one file per filetype. In case of Slick, not only a single file was specified as the main stylesheet file, but `slick/slick.css`, `slick/slick.less`, and `slick/slick.scss` as well. I think the SCSS version can be considered the best case scenario.

refs #2339