### PR TITLE
Check if addSlide function receives a object

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -199,6 +199,10 @@
     Slick.prototype.addSlide = Slick.prototype.slickAdd = function(markup, index, addBefore) {
 
         var _ = this;
+         
+        if (typeof(markup) != 'string') {
+            throw new TypeError('Add-Slide function expects a string');
+        }
 
         if (typeof(index) === 'boolean') {
             addBefore = index;


### PR DESCRIPTION
If the 'markup' function argument is an e.g. JQuery object
the 'addSlide' function crashes the slider without throwing
and error.
This commit adds a type check for the 'markup' parameter
that throws a TypeError.