### PR TITLE
Added outer edge clipping

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -65,6 +65,7 @@
                 initialSlide: 0,
                 lazyLoad: 'ondemand',
                 mobileFirst: false,
+                outerEdgeLimit: false,
                 pauseOnHover: true,
                 pauseOnFocus: true,
                 pauseOnDotsHover: false,
@@ -1151,6 +1152,14 @@
                 }
 
                 targetLeft += (_.$list.width() - targetSlide.outerWidth()) / 2;
+            } else if (_.options.outerEdgeLimit) {
+                var lastSlide,
+                    lastLeft,
+                    outerEdgeLimit;
+                lastSlide = _.$slides.last();
+                lastLeft = lastSlide[0] ? lastSlide[0].offsetLeft * -1 : 0;
+                outerEdgeLimit = lastLeft - lastSlide.width() + this.$slider.width();
+                targetLeft = Math.min(Math.max(targetLeft, outerEdgeLimit), 0);
             }
         }
 


### PR DESCRIPTION
Outer edge clipping only affects slick with variable width on.

This new option `outerEdgeLimit` allows the last element of the slider to stop at its limit, instead of leaving empty space.