### PR TITLE
Check hasOwnProperty before accessing field

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1773,9 +1773,9 @@
             for ( breakpoint in responsiveSettings ) {
 
                 l = _.breakpoints.length-1;
-                currentBreakpoint = responsiveSettings[breakpoint].breakpoint;
 
                 if (responsiveSettings.hasOwnProperty(breakpoint)) {
+                    currentBreakpoint = responsiveSettings[breakpoint].breakpoint;
 
                     // loop through the breakpoints and cut out any existing
                     // ones with the same breakpoint number, we don't want dupes.


### PR DESCRIPTION
I've been getting `Cannot read property 'breakpoint' of undefined` [here](https://github.com/kenwheeler/slick/blob/95e1be8/slick/slick.js#L1776) from our Javascript error tracking system. I have not been able to reproduce this outside of a testcase, and I am unsure what exactly is causing this error (perhaps some third party abusing the Array prototype), but this should solve it. 

Testcase [here](http://jsfiddle.net/ey086m7u/).