### PR TITLE
update on ready event listeners to jquery 3 compliant syntax

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -794,7 +794,6 @@
         $('[draggable!=true]', _.$slideTrack).off('dragstart', _.preventDefault);
 
         $(window).off('load.slick.slick-' + _.instanceUid, _.setPosition);
-        $(document).off('ready.slick.slick-' + _.instanceUid, _.setPosition);
 
     };
 
@@ -1406,7 +1405,7 @@
         $('[draggable!=true]', _.$slideTrack).on('dragstart', _.preventDefault);
 
         $(window).on('load.slick.slick-' + _.instanceUid, _.setPosition);
-        $(document).on('ready.slick.slick-' + _.instanceUid, _.setPosition);
+        $(document).ready(_.setPosition);
 
     };
 


### PR DESCRIPTION
Addresses #2676 created by @KolyaKorruptis, which points out that jQuery 3 has deprecated `.on('ready')`

There were only two instances where slick used, and one was (I think superfluously?) leveraging jQuery's `.off` method. I deleted that line and updated the other to `.ready(...function...)`

[Tests w/ latest jquery](https://codepen.io/leggomuhgreggo/live/Gromzb)

Let me know if there's any issues!

Thanks
