### PR TITLE
fixed syntax related to [dir="rtl"]

### DIFF
--- a/slick/slick-theme.less
+++ b/slick/slick-theme.less
@@ -76,13 +76,13 @@
 
 .slick-prev {
     left: -25px;
-    &[dir="rtl"] {
+    [dir="rtl"] & {
         left: auto;
         right: -25px;
     }
     &:before {
         content: @slick-prev-character;
-        &[dir="rtl"] {
+        [dir="rtl"] & {
             content: @slick-next-character;
         }
     }
@@ -90,13 +90,13 @@
 
 .slick-next {
     right: -25px;
-    &[dir="rtl"] {
+    [dir="rtl"] & {
         left: -25px;
         right: auto;
     }
     &:before {
         content: @slick-next-character;
-        &[dir="rtl"] {
+        [dir="rtl"] & {
             content: @slick-prev-character;
         }
     }


### PR DESCRIPTION
Attribute selector syntax was incorrect in this file. For example,
```
.slick-next {
  &:before {
    &[dir="rtl"] {
      // stuff
    }
  }
}
```
would compile to `.slick-next:before[dir="rtl"]`, when what was intended was `[dir="rtl"] .slick-next:before`, and this would cause browsers to ignore that rule.

I discovered this problem when I minified my compiled stylesheet with clean-css and the Next arrow disappeared: the `<button>` was still there but it had no `::before` pseudo element which is where the arrow exists. clean-css grouped the `.slick-next:before` rule that defined the arrow with `.slick-prev`'s broken `:before[dir="rtl"]` rule, causing both rules to be ignored:
```
.slick-next:before,.slick-prev:before[dir=rtl]{content:"→"}
```
The syntax is correct in `slick-theme.scss`.