### PR TITLE
Accessibility bug fix: aria-selected always true for first pagination…

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1304,7 +1304,7 @@
                     'id': 'slick-slide' + _.instanceUid + i + ''
                 });
             })
-                .first().attr('aria-selected', 'true').end()
+                .siblings('.slick-active').attr('aria-selected', 'true').end()
                 .find('button').attr('role', 'button').end()
                 .closest('div').attr('role', 'toolbar');
         }


### PR DESCRIPTION
… control button.

The "aria-select" attribute value is always set to "true" on the first pagination control element. This fix should correct the behavior when navigating to another control element.