### PR TITLE
Fix for lazyload on demand with dots unexpected behaviour.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .sass-cache
 node_modules
+.idea

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1453,7 +1453,7 @@
     Slick.prototype.lazyLoad = function() {
 
         var _ = this,
-            loadRange, cloneRange, rangeStart, rangeEnd;
+            loadRange, cloneRange, rangeStart, rangeEnd, slideToBegin;
 
         function loadImages(imagesScope) {
 
@@ -1518,7 +1518,8 @@
                 rangeEnd = 2 + (_.options.slidesToShow / 2 + 1) + _.currentSlide;
             }
         } else {
-            rangeStart = _.options.infinite ? _.options.slidesToShow + _.currentSlide : _.currentSlide;
+            slideToBegin =  _.currentSlide - Math.max(0, _.currentSlide + _.options.slidesToShow - _.slideCount);
+            rangeStart = _.options.infinite ? _.options.slidesToShow + slideToBegin : slideToBegin;
             rangeEnd = Math.ceil(rangeStart + _.options.slidesToShow);
             if (_.options.fade === true) {
                 if (rangeStart > 0) rangeStart--;


### PR DESCRIPTION
Code example for the unexpected behaviour: https://jsfiddle.net/Rishanthan/wL10oec8/3/ 

**Steps to reproduce the problem**

1.Define a carousel with Lazyload ondemand.
2.Set slides to scroll in a way, which the last view uses some images from the previous view to fill the final view.
3.Click on the final dot to navigate to the final view of the carousel without navigating to other views.