### PR TITLE
Sample code to prevent partial images from being displayed

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -5,14 +5,12 @@
 \__ \ | | (__|   < _ | \__ \
 |___/_|_|\___|_|\_(_)/ |___/
                    |__/
-
  Version: 1.6.0
   Author: Ken Wheeler
  Website: http://kenwheeler.github.io
     Docs: http://kenwheeler.github.io/slick
     Repo: http://github.com/kenwheeler/slick
   Issues: http://github.com/kenwheeler/slick/issues
-
  */
 /* global window, document, define, jQuery, setInterval, clearInterval */
 (function(factory) {
@@ -65,6 +63,7 @@
                 initialSlide: 0,
                 lazyLoad: 'ondemand',
                 mobileFirst: false,
+                partialImages: true,
                 pauseOnHover: true,
                 pauseOnFocus: true,
                 pauseOnDotsHover: false,
@@ -314,6 +313,7 @@
                 } else {
                     animProps[_.animType] = 'translate3d(0px,' + targetLeft + 'px, 0px)';
                 }
+
                 _.$slideTrack.css(animProps);
 
                 if (callback) {
@@ -1977,12 +1977,18 @@
         _.listWidth = _.$list.width();
         _.listHeight = _.$list.height();
 
-
         if (_.options.vertical === false && _.options.variableWidth === false) {
             _.slideWidth = Math.ceil(_.listWidth / _.options.slidesToShow);
             _.$slideTrack.width(Math.ceil((_.slideWidth * _.$slideTrack.children('.slick-slide').length)));
 
         } else if (_.options.variableWidth === true) {
+            if (_.options.partialImages === false) {
+                var carouselWidth = 0;
+                $.each($('.slick-active'), function(index, image) {
+                    carouselWidth += image.clientWidth;
+                });
+                $('.slick-slider').width(carouselWidth);
+            }
             _.$slideTrack.width(5000 * _.slideCount);
         } else {
             _.slideWidth = Math.ceil(_.listWidth);


### PR DESCRIPTION
Great carousel by the way!  The code is also clean and well structured.  From now on, I'm going to make it my go-to carousel.

This is more of a feature request than a pull request.  In order to meet a project requirement, I had to modify the carousel to prevent partial images from displaying so I made some minor changes to code.  The changes could be coded better and won't work with all settings.  Also, the changes cause the carousel to jerk a little.  I'm only posting them as an example.

These are the settings it was implemented with:

```
$('#my-carousel').slick({
  arrows: false,
  autoplay: true,
  autoplaySpeed: 3000,
  partialImages: false,
  responsive: [{
    breakpoint: 1200,
      settings: {
        slidesToShow: 7
      }
    }, {
    breakpoint: 992,
      settings: {
        slidesToShow: 6
      }
    }, {
    breakpoint: 768,
      settings: {
        slidesToShow: 4
      }
    }, {
    breakpoint: 576,
      settings: {
        slidesToShow: 2
      }
    }],
  slidesToScroll: 1,
  slidesToShow: 7,
  variableWidth: true
});
```