### PR TITLE
when using lazyLoad with srcset, do not download the image twice

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1503,6 +1503,8 @@
 
                 };
 
+                if (imageSrcSet) imageToLoad.srcset = imageSrcSet;
+                if (imageSizes) imageToLoad.sizes = imageSizes;
                 imageToLoad.src = imageSource;
 
             });
@@ -1738,6 +1740,8 @@
 
             };
 
+            if (imageSrcSet) imageToLoad.srcset = imageSrcSet;
+            if (imageSizes) imageToLoad.sizes = imageSizes;
             imageToLoad.src = imageSource;
 
         } else {


### PR DESCRIPTION
This is a fix for pull request #2681 by fozzleberry, titled "Lazy loading with srcset and sizes attributes"

The problem I was seeing was that the in-memory image used for triggering onload was only being loaded with src, not srcset and sizes, so it was making a different decision about which image size to use than the image in the DOM.  Adding srcset and sizes to the in-memory image helps the browser make the same decision both times, and thus not download two different sizes of the same image.