### PR TITLE
Fix for jQuery 3

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1405,7 +1405,7 @@
         $('[draggable!=true]', _.$slideTrack).on('dragstart', _.preventDefault);
 
         $(window).on('load.slick.slick-' + _.instanceUid, _.setPosition);
-        $(document).ready(_.setPosition);
+        $(_.setPosition);
 
     };
 


### PR DESCRIPTION
https://api.jquery.com/ready/

> jQuery offers several ways to attach a function that will run when the DOM is ready. All of the following syntaxes are equivalent:
>
> $( handler )
> $( document ).ready( handler )
> $( "document" ).ready( handler )
> $( "img" ).ready( handler )
> $().ready( handler )
> As of jQuery 3.0, only the first syntax is recommended; the other syntaxes still work but are deprecated.