### PR TITLE
Orientation change responsive slider breakpoint resize bug

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -594,7 +594,7 @@
         var _ = this,
             breakpoint, targetBreakpoint, respondToWidth, triggerBreakpoint = false;
         var sliderWidth = _.$slider.width();
-        var windowWidth = window.innerWidth || $(window).width();
+        var windowWidth = $(window).width();
 
         if (_.respondTo === 'window') {
             respondToWidth = windowWidth;


### PR DESCRIPTION
window.innerWidth does not change on orientation change on some mobile devices, thus making slider not to resize.