### PR TITLE
Swipe left bug on not infinite slider

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -744,6 +744,10 @@
                 prevNavigable = navigables[n];
             }
         }
+         
+        if (index + _.options.slidesToShow > navigables.length) {
+            index = navigables.length - _.options.slidesToShow;
+        }
 
         return index;
     };


### PR DESCRIPTION
When slides to swipe left are more than actual swipes, index will be to big and slide will not occur. This fixes the case.