### PR TITLE
variableWidth & centerMode & non infinite

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1150,6 +1150,20 @@
                 }
 
                 targetLeft += (_.$list.width() - targetSlide.outerWidth()) / 2;
+                
+                if (_.options.infinite === false) {
+                    var children = _.$slideTrack.children('.slick-slide');
+                    var sum = 0;
+                    for (var i=0; i<children.length; i++){
+                        sum += children[i].clientWidth;
+                    }
+                    if (targetLeft > 0) {
+                        targetLeft = 0;
+                    }
+                    if (targetLeft < sum*(-1) + _.$list.width()) {
+                        targetLeft = sum*(-1) + _.$list.width();
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
I added two extra conditions to remove the white-space at each end of the slider when using with variableWidth & centerMode & non infinite. I didn't know if there is a variable which adds all the widths of all the slides together so I made a loop for this. Also I'm aware that this value could change over time (lazy loading which I also use). Note that on lines 1163 and 1164 I use addition instead of subtraction because we are already dealing with negative numbers.
I don't know if this interferers with rtl mode, I didn't check it.

My setup looks like this:

$('.slickslider').slick({
	dots: false,
	arrows: true,
	useCSS: false,
	//useCSS: true,
	//infinite: true,
	infinite: false,
	slidesToShow: 4,
	//centerMode: false,
	centerMode: true,
	variableWidth: true,
	//lazyLoad: 'progressive',
	lazyLoad: 'ondemand',
	//initialSlide: initialSlide,
	prevArrow: '<div class="prevArrow"></div>',
	nextArrow: '<div class="nextArrow"></div>',
	//cssEase: 'ease'
	responsive: [
	{
		breakpoint: 767,
		settings: {
			arrows: false,
			infinite: false,
			slidesToShow: 1,
			variableWidth: false
		}
	}
	]
});

var hash = window.location.hash.substr(1);
if ($.isNumeric(hash) && hash>1){
	$('.slickslider').slick('slickGoTo',hash,true);
}

$('.slickslider').on('afterChange', function(event, slick, currentSlide){
	window.location.hash = currentSlide;
});