### PR TITLE
Fix bullet and click event problem when slideCount <= slidesToShow

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -481,7 +481,7 @@
         var _ = this,
             i, dot;
 
-        if (_.options.dots === true && _.slideCount > _.options.slidesToShow) {
+        if (_.options.dots === true) {
 
             _.$slider.addClass('slick-dotted');
 
@@ -1335,7 +1335,7 @@
 
         var _ = this;
 
-        if (_.options.dots === true && _.slideCount > _.options.slidesToShow) {
+        if (_.options.dots === true) {
             $('li', _.$dots).on('click.slick', {
                 message: 'index'
             }, _.changeSlide);

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1039,10 +1039,14 @@
         var pagerQty = 0;
 
         if (_.options.infinite === true) {
-            while (breakPoint < _.slideCount) {
-                ++pagerQty;
-                breakPoint = counter + _.options.slidesToScroll;
-                counter += _.options.slidesToScroll <= _.options.slidesToShow ? _.options.slidesToScroll : _.options.slidesToShow;
+            if (_.slideCount <= _.options.slidesToShow) {
+                 ++pagerQty;
+            } else {
+                while (breakPoint < _.slideCount) {
+                    ++pagerQty;
+                    breakPoint = counter + _.options.slidesToScroll;
+                    counter += _.options.slidesToScroll <= _.options.slidesToShow ? _.options.slidesToScroll : _.options.slidesToShow;
+                }
             }
         } else if (_.options.centerMode === true) {
             pagerQty = _.slideCount;

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1634,7 +1634,9 @@
 
             _.animating = false;
 
-            _.setPosition();
+            if (_.slideCount > _.options.slidesToShow) {
+                _.setPosition();
+            }
 
             _.swipeLeft = null;
 
@@ -2394,8 +2396,9 @@
 
         if (_.slideCount <= _.options.slidesToShow) {
 
-            _.setSlideClasses(index);
-            _.asNavFor(index);
+            //_.setSlideClasses(index);
+            //_.asNavFor(index);
+            _.slideHandler(index, false, true);
             return;
 
         }
@@ -2419,9 +2422,9 @@
             return;
         }
 
-        if (_.slideCount <= _.options.slidesToShow) {
+        /*if (_.slideCount <= _.options.slidesToShow) {
             return;
-        }
+        }*/
 
         if (sync === false) {
             _.asNavFor(index);

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2396,8 +2396,6 @@
 
         if (_.slideCount <= _.options.slidesToShow) {
 
-            //_.setSlideClasses(index);
-            //_.asNavFor(index);
             _.slideHandler(index, false, true);
             return;
 
@@ -2421,10 +2419,6 @@
         if (_.options.fade === true && _.currentSlide === index) {
             return;
         }
-
-        /*if (_.slideCount <= _.options.slidesToShow) {
-            return;
-        }*/
 
         if (sync === false) {
             _.asNavFor(index);


### PR DESCRIPTION
Fix for the [Issue #2821](https://github.com/kenwheeler/slick/issues/2821)
This PR enable click events if number of slides is less than slidesToShow.
One bullet is shown when slideCount is lesser or equal than slidesToShow, also enabling currentSlide to be reset after changing its value.