### PR TITLE
jQuery's 'ready' event deprecated

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -131,7 +131,7 @@ export default {
     $("[draggable!=true]", this.$slideTrack).on("dragstart", this.preventDefault);
 
     $(window).on("load.slick.slick-" + this.instanceUid, this.setPosition);
-    $(document).on("ready.slick.slick-" + this.instanceUid, this.setPosition);
+    $(this.setPosition);
   },
   keyHandler(event: Object) {
     //Dont slide if the cursor is inside the form fields and arrow keys are pressed


### PR DESCRIPTION
The only acceptable way to handle the ready event in jQuery is now: 
`jQuery(function($) { /** whatever **/ });`