### PR TITLE
Check for "module" object (use single quotes)

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -19,7 +19,7 @@
     'use strict';
     if (typeof define === 'function' && define.amd) {
         define(['jquery'], factory);
-    } else if (typeof exports !== 'undefined') {
+    } else if (typeof module === 'object') {
         module.exports = factory(require('jquery'));
     } else {
         factory(jQuery);


### PR DESCRIPTION
Fixes https://github.com/kenwheeler/slick/issues/2847