### PR TITLE
Prepend Semicolon

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -15,7 +15,7 @@
 
  */
 /* global window, document, define, jQuery, setInterval, clearInterval */
-(function(factory) {
+;(function(factory) {
     'use strict';
     if (typeof define === 'function' && define.amd) {
         define(['jquery'], factory);


### PR DESCRIPTION
We've had several issues where other packages fail when called just before slick.

The reason seems to be that those packages are missing a semicolon at the end of their code, which causes errors when followed by an IIFE, as is the case with Slick.

So I prepended a courtesy semicolon to close the statements of libraries with that oversight.