### PR TITLE
Took Out Described-By Attribute

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1288,13 +1288,7 @@
 
         _.$slides.not(_.$slideTrack.find('.slick-cloned')).each(function(i) {
             $(this).attr('role', 'option');
-
-            //Evenly distribute aria-describedby tags through available dots.
-            var describedBySlideId = _.options.centerMode ? i : Math.floor(i / _.options.slidesToShow);
-
-            if (_.options.dots === true) {
-                $(this).attr('aria-describedby', 'slick-slide' + _.instanceUid + describedBySlideId + '');
-            }
+             
         });
 
         if (_.$dots !== null) {


### PR DESCRIPTION
The aria-described-by attributes make the page fail WAVE testing. This patch removes them.