### PR TITLE
Update dots alignment

### DIFF
--- a/slick/slick-theme.less
+++ b/slick/slick-theme.less
@@ -111,6 +111,7 @@
 .slick-dots {
     position: absolute;
     bottom: -25px;
+    left: 0;
     list-style: none;
     display: block;
     text-align: center;


### PR DESCRIPTION
I've noticed that every time i use slick (awesome plugin) the dots bar is not correctly aligned with the slider; figured out that a simple "left: 0;" will solve this problem!

Thanks for this awesome plugin!