### PR TITLE
Removed Aria-pressed label for html validation reasons

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2941,20 +2941,12 @@
             _.$dots
                 .find('li')
                     .removeClass('slick-active')
-                    .end()
-                .find('button')
-                    .attr({
-                        'aria-pressed': false
-                    });
+                    .end();
 
             _.$dots
                 .find('li')
                 .eq(Math.floor(_.currentSlide / _.options.slidesToScroll))
-                .addClass('slick-active')
-                .find('button')
-                .attr({
-                    'aria-pressed': true
-                });
+                .addClass('slick-active');
 
         }
 


### PR DESCRIPTION
In order to pass HTML5 validation (https://validator.w3.org/nu) and be fully WCAG AA compliant, the Aria-pressed label was removed, as it is not allowed on an li element at that point. 

Codepen for test cases https://codepen.io/tbirdsall/pen/PjXwGW