### PR TITLE
Replacing constant window/document wrapping with single wrapped reference

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -3,6 +3,9 @@
 
 const $ = window.$ || window.jQuery;
 
+const $window = $(window);
+const $document = $(document);
+
 export default {
   cleanUpEvents() {
     if (this.options.dots && this.$dots !== null) {
@@ -27,7 +30,7 @@ export default {
 
     this.$list.off("click.slick", this.clickHandler);
 
-    $(document).off(this.visibilityChange, this.visibility);
+    $document.off(this.visibilityChange, this.visibility);
 
     this.$list.off("mouseenter.slick", $.proxy(this.setPaused, this, true));
     this.$list.off("mouseleave.slick", $.proxy(this.setPaused, this, false));
@@ -40,14 +43,14 @@ export default {
       $(this.$slideTrack).children().off("click.slick", this.selectHandler);
     }
 
-    $(window).off("orientationchange.slick.slick-" + this.instanceUid, this.orientationChange);
+    $window.off("orientationchange.slick.slick-" + this.instanceUid, this.orientationChange);
 
-    $(window).off("resize.slick.slick-" + this.instanceUid, this.resize);
+    $window.off("resize.slick.slick-" + this.instanceUid, this.resize);
 
     $("[draggable!=true]", this.$slideTrack).off("dragstart", this.preventDefault);
 
-    $(window).off("load.slick.slick-" + this.instanceUid, this.setPosition);
-    $(document).off("ready.slick.slick-" + this.instanceUid, this.setPosition);
+    $window.off("load.slick.slick-" + this.instanceUid, this.setPosition);
+    $document.off("ready.slick.slick-" + this.instanceUid, this.setPosition);
   },
   focusHandler() {
     this.$slider.on("focus.slick blur.slick", "*", (event) => {
@@ -110,7 +113,7 @@ export default {
 
     this.$list.on("click.slick", this.clickHandler);
 
-    $(document).on(this.visibilityChange, $.proxy(this.visibility, this));
+    $document.on(this.visibilityChange, $.proxy(this.visibility, this));
 
     this.$list.on("mouseenter.slick", $.proxy(this.setPaused, this, true));
     this.$list.on("mouseleave.slick", $.proxy(this.setPaused, this, false));
@@ -123,15 +126,15 @@ export default {
       $(this.$slideTrack).children().on("click.slick", this.selectHandler);
     }
 
-    $(window).on("orientationchange.slick.slick-" + this.instanceUid,
+    $window.on("orientationchange.slick.slick-" + this.instanceUid,
       $.proxy(this.orientationChange, this));
 
-    $(window).on("resize.slick.slick-" + this.instanceUid, $.proxy(this.resize, this));
+    $window.on("resize.slick.slick-" + this.instanceUid, $.proxy(this.resize, this));
 
     $("[draggable!=true]", this.$slideTrack).on("dragstart", this.preventDefault);
 
-    $(window).on("load.slick.slick-" + this.instanceUid, this.setPosition);
-    $(document).on("ready.slick.slick-" + this.instanceUid, this.setPosition);
+    $window.on("load.slick.slick-" + this.instanceUid, this.setPosition);
+    $(this.setPosition);
   },
   keyHandler(event: Object) {
     //Dont slide if the cursor is inside the form fields and arrow keys are pressed
@@ -159,10 +162,10 @@ export default {
     event.preventDefault();
   },
   resize() {
-    if ($(window).width() !== this.windowWidth) {
+    if ($window.width() !== this.windowWidth) {
       clearTimeout(this.windowDelay);
       this.windowDelay = window.setTimeout(() => {
-        this.windowWidth = $(window).width();
+        this.windowWidth = $window.width();
         this.checkResponsive();
         if (!this.unslicked) {
           this.setPosition();


### PR DESCRIPTION
Pedantic, asinine, triflin', "who the f*ck does this guy think he is." These are just a few of the slurs used to describe this pull request.

And yet, here we are.

PROMPT: I was trying to track down where `drag` gets its threshold from and noticed `window` and `document` were getting fresh JQuery wrappers with every use. It made me curious more than anything so I began digging in to see what, if any, performance gains there were to referencing a single, global instance of these instead of rewrapping them every time.

CHANGES: I set `const` declarations at the top and used them to replace all instances of `$(window)` and `$(document)`.

PAIN-POINT: JQuery does a great job of detecting if `window` is the object getting wrapped and, as far as I can determine, not rewrapping it. I can't tell if it's doing this for `document` or not. Either way, it has to do logic to make that determination. Logic that we can just do from our end to help it along.

Additionally, [the performance gains that I could find](https://jsperf.com/caching-jquery-selectors) seem more relevant to looped instances than seldom used one-offs, so really this comes down to a matter of style/opinion. 

My enthusiasm isn't nearly as high as my curiosity was, so I'm not pushing this issue too hard. If I hadn't noticed that work was being done on a completely fresh version, I probably wouldn't be PR'ing at all, but this seems like a good time to make this update if it needs to get made at all.

I made this test with version 1.6.0: https://codepen.io/nominalaeon/project/editor/Dnnxzj/#0

I've also implemented the change in a microsite that is doing some heavy lifting slider stuff using angular-slick and nested sliders. Here are some screenshots:

![slider-1](https://user-images.githubusercontent.com/1110469/28322193-17b3f540-6b9b-11e7-8aab-66d46d484a9b.png)
![slider-2](https://user-images.githubusercontent.com/1110469/28322203-1b688e9e-6b9b-11e7-9dbf-05b9342de61b.png)

In summation, gentlemen, I propose you accept this change and embrace it in your hearts. As true believers of JQuery it's our job, nay our Bob-given duty, to use it responsibly and set good examples for the children.

Or not, whatever.