### PR TITLE
Not to scroll when infinite scrolling isn't on

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2490,7 +2490,7 @@
         if (_.options.infinite === false && _.options.centerMode === false && (index < 0 || index > _.getDotCount() * _.options.slidesToScroll)) {
             if (_.options.fade === false) {
                 targetSlide = _.currentSlide;
-                if (dontAnimate !== true) {
+                if (dontAnimate !== true && _.slideCount > _.options.slidesToShow) {
                     _.animateSlide(slideLeft, function() {
                         _.postSlide(targetSlide);
                     });
@@ -2502,7 +2502,7 @@
         } else if (_.options.infinite === false && _.options.centerMode === true && (index < 0 || index > (_.slideCount - _.options.slidesToScroll))) {
             if (_.options.fade === false) {
                 targetSlide = _.currentSlide;
-                if (dontAnimate !== true) {
+                if (dontAnimate !== true && _.slideCount > _.options.slidesToShow) {
                     _.animateSlide(slideLeft, function() {
                         _.postSlide(targetSlide);
                     });
@@ -2572,7 +2572,7 @@
             return;
         }
 
-        if (dontAnimate !== true) {
+        if (dontAnimate !== true && _.slideCount > _.options.slidesToShow) {
             _.animateSlide(targetLeft, function() {
                 _.postSlide(animSlide);
             });


### PR DESCRIPTION
Hi.

I am seeing a case where swiping the main image causes the nav to scroll even when infinite scroll isn't on.

So.. I am using the following options:
```
$sliderNav.slick({
    slidesToShow: 4,
    slidesToScroll: 1,
    asNavFor: '.product-detail-slider',
    dots: false,
    vertical: true,
    focusOnSelect: true
});
```
and the issue happens when the number of images are 3 or less (4 images can fit into the space).
When the number of images are 3, then the infinite scrolling seems to be off (even though infinite option is set to true).
However swiping the main image causes the nav image to scroll off the screen.

You can check the bug here -> https://www.ounass.ae/shop-gucci-pastel-pink-gg-marmont-wallet-211544599.html
It's using slick slider 1.7.1. Try swiping the product image.

So I think this is an issue in slick itself, and applied a fix to the best of my knowledge.

Thanks.