### PR TITLE
Update jsDelivr CDN links

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,15 +22,15 @@ to serve the files as close, and fast as possible to your users:
 Just add a link to the css file in your `<head>`:
 
 ```html
-<link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/gh/kenwheeler/slick@1.7.1/slick/slick.css"/>
+<link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/npm/slick-carousel@1.7.1/slick/slick.css"/>
 <!-- Add the slick-theme.css if you want default styling -->
-<link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/gh/kenwheeler/slick@1.7.1/slick/slick-theme.css"/>
+<link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/npm/slick-carousel@1.7.1/slick/slick-theme.css"/>
 ```
 
 Then, before your closing ```<body>``` tag add:
 
 ```html
-<script type="text/javascript" src="//cdn.jsdelivr.net/gh/kenwheeler/slick@1.7.1/slick/slick.min.js"></script>
+<script type="text/javascript" src="//cdn.jsdelivr.net/npm/slick-carousel@1.7.1/slick/slick.min.js"></script>
 ```
 
 #### Package Managers


### PR DESCRIPTION
First, big congrats - [slick receives more than 2,6 B requests per month at jsDelivr](https://www.jsdelivr.com/package/npm/slick-carousel), which makes it the most popular package we host!

While our new back-end supports serving files from both npm and GitHub, we recommend always using only one of these methods for every package, with npm being the preferred one (using only npm means you can get detailed package usage statistics and npm packages are also searchable on our website).

I updated the links to use our npm endpoint. I also noticed you don't provide minified CSS files in your package. jsDelivr can now do on-demand minification, which means you could link to the following files for minified versions:
 - https://cdn.jsdelivr.net/npm/slick-carousel@1.7.1/slick/slick.min.css
 - https://cdn.jsdelivr.net/npm/slick-carousel@1.7.1/slick/slick-theme.min.css

Let me know if I should update the links to use minified CSS files instead.