### PR TITLE
Changed the logic for adding aria describedby attribute

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1322,9 +1322,12 @@
                 });
 
                 if (slideControlIndex !== -1) {
-                    $(this).attr({
-                        'aria-describedby': 'slick-slide-control' + _.instanceUid + slideControlIndex
-                    });
+                   var ariaButtonControl = 'slick-slide-control' + _.instanceUid + slideControlIndex
+                   if ($('#' + ariaButtonControl).length) {
+                     $(this).attr({
+                         'aria-describedby': ariaButtonControl
+                     });
+                   }
                 }
             });
 
@@ -1697,7 +1700,7 @@
 
             if (_.options.accessibility === true) {
                 _.initADA();
-                
+
                 if (_.options.focusOnChange) {
                     var $currentSlide = $(_.$slides.get(_.currentSlide));
                     $currentSlide.attr('tabindex', 0).focus();


### PR DESCRIPTION
There was a small bug where if the number of slides in a carousel is less than or equal to the slidesToShow variable, the aria-describedby attribute was still being added (with the next/prev button ID) even though the next/prev buttons are not in the DOM at that point.

This fix just checks to see if the corresponding button exists before adding the aria-describedby attribute.

Codepen for test cases https://codepen.io/tbirdsall/pen/PjXwGW