### PR TITLE
when focusOnChange is false -> remove attr tabindex

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1354,7 +1354,11 @@
         }
 
         for (var i=_.currentSlide, max=i+_.options.slidesToShow; i < max; i++) {
-            _.$slides.eq(i).attr('tabindex', 0);
+          if (_.options.focusOnChange) {
+            _.$slides.eq(i).attr({'tabindex': '0'});
+          } else {
+            _.$slides.eq(i).removeAttr('tabindex');
+          }
         }
 
         _.activateADA();


### PR DESCRIPTION
When tabbing through the slides, they have tabindex 0 even though focusOnChange is false. 
The issue appears from initADA function where the slides that are in view are given the value 0 for tabidex.

I have added an if for the verification of the focusOnChange option.

[screenshot here](https://gyazo.com/da091bcfb3a0ada43cf51ed698493983)

 ```
      if (_.options.focusOnChange) {
            _.$slides.eq(i).attr({'tabindex': '0'});
          } else {
            _.$slides.eq(i).removeAttr('tabindex');
          }
```

I believe this is the only thing that is missing from [#3032](https://github.com/kenwheeler/slick/pull/3032)

[Issue here](http://jsfiddle.net/e7pumpdL/).