### PR TITLE
User-select: none only when draggable: true

### DIFF
--- a/slick/slick.css
+++ b/slick/slick.css
@@ -6,10 +6,10 @@
     display: block;
     box-sizing: border-box;
 
-    -webkit-user-select: none;
-       -moz-user-select: none;
-        -ms-user-select: none;
-            user-select: none;
+    -webkit-user-select: text;
+       -moz-user-select: text;
+        -ms-user-select: text;
+            user-select: text;
 
     -webkit-touch-callout: none;
     -khtml-user-select: none;
@@ -36,6 +36,14 @@
 {
     cursor: pointer;
     cursor: hand;
+}
+.slick-list.draggable
+{
+    -webkit-user-select: none;
+     -khtml-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
 }
 
 .slick-slider .slick-track,

--- a/slick/slick.less
+++ b/slick/slick.less
@@ -5,11 +5,11 @@
     display: block;
     box-sizing: border-box;
     -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
+    -webkit-user-select: text;
+    -khtml-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
+    user-select: text;
     -ms-touch-action: pan-y;
     touch-action: pan-y;
     -webkit-tap-highlight-color: transparent;
@@ -28,6 +28,14 @@
     &.dragging {
         cursor: pointer;
         cursor: hand;
+    }
+
+    &.draggable {
+      -webkit-user-select: none;
+      -khtml-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
     }
 }
 .slick-slider .slick-track,

--- a/slick/slick.scss
+++ b/slick/slick.scss
@@ -5,11 +5,11 @@
     display: block;
     box-sizing: border-box;
     -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
+    -webkit-user-select: text;
+    -khtml-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
+    user-select: text;
     -ms-touch-action: pan-y;
     touch-action: pan-y;
     -webkit-tap-highlight-color: transparent;
@@ -28,6 +28,14 @@
     &.dragging {
         cursor: pointer;
         cursor: hand;
+    }
+
+    &.draggable {
+      -webkit-user-select: none;
+      -khtml-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
     }
 }
 .slick-slider .slick-track,


### PR DESCRIPTION
PR for #826 to make text selectable unless `draggable: true` (default).

Demo here. All sliders have `draggable: false` and text is selectable without affecting behavior. https://codepen.io/pedroadame/pen/oGXoxR