### PR TITLE
Fixing "slickness.not is not a function" bug!

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -17,12 +17,12 @@
 /* global window, document, define, jQuery, setInterval, clearInterval */
 ;(function(factory) {
     'use strict';
-    if (typeof define === 'function' && define.amd) {
+    if (window.hasOwnProperty('jQuery') && typeof jQuery === 'function') {
+        factory(window.jQuery || jQuery);
+    } else if (typeof define === 'function' && define.amd) {
         define(['jquery'], factory);
     } else if (typeof exports !== 'undefined') {
         module.exports = factory(require('jquery'));
-    } else {
-        factory(jQuery);
     }
 
 }(function($) {


### PR DESCRIPTION
I have tried to add this plugin in my project (angular based), but i have been blocked by error "slickness.not is not a function", i have checked how jQuery are loaded and after put modified condition:
```
if (window.hasOwnProperty('jQuery') && typeof jQuery === 'function') {
        factory(window.jQuery || jQuery);
    } else if (typeof define === 'function' && define.amd) {
        define(['jquery'], factory);
    } else if (typeof exports !== 'undefined') {
        module.exports = factory(require('jquery'));
    }
```

Everything working ...