### PR TITLE
Update slick-theme.scss

### DIFF
--- a/slick/slick-theme.scss
+++ b/slick/slick-theme.scss
@@ -78,6 +78,7 @@ $slick-opacity-not-active: 0.25 !default;
     padding: 0;
     border: none;
     outline: none;
+    z-index: 1;
     &:hover, &:focus {
         outline: none;
         background: transparent;


### PR DESCRIPTION
Fix the problem that left arrows hide under the slides when customizing the position of arrows.