### PR TITLE
Suggesting round down so the entire slide shows on odd resolution screens.

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2048,7 +2048,7 @@
 
 
         if (_.options.vertical === false && _.options.variableWidth === false) {
-            _.slideWidth = Math.ceil(_.listWidth / _.options.slidesToShow);
+            _.slideWidth = Math.floor(_.listWidth / _.options.slidesToShow);
             _.$slideTrack.width(Math.ceil((_.slideWidth * _.$slideTrack.children('.slick-slide').length)));
 
         } else if (_.options.variableWidth === true) {


### PR DESCRIPTION
#3264 in the SetDimensions method, we should probably round down instead of up so 1 pixel isn't cut off on odd resolution screens.