### PR TITLE
setSlidesClasses selector incorrect when index is 0

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2328,7 +2328,7 @@
                 if (index === 0) {
 
                     allSlides
-                        .eq(allSlides.length - 1 - _.options.slidesToShow)
+                        .eq(0)
                         .addClass('slick-center');
 
                 } else if (index === _.slideCount - 1) {

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2328,7 +2328,7 @@
                 if (index === 0) {
 
                     allSlides
-                        .eq(0)
+                        .eq(allSlides.length - 1 - _.options.slidesToShow - (_.slideCount - 1 - _.options.slidesToShow))
                         .addClass('slick-center');
 
                 } else if (index === _.slideCount - 1) {


### PR DESCRIPTION
Mainly to fix #3271 where users are complaining about center mode jumping when going from last to first slide, I think there are other tickets where this may be the cause of jerky animations

This js fiddle shows the issue http://jsfiddle.net/paulbarrett79/5z11Lo7v/2/
This fix ensures the correct clone gets the slick-center class when going from last to first in center, infinite mode.

My fix is shown working here https://codepen.io/PaulBarrett79/pen/WdWYaO