### PR TITLE
fix vertical item alignment in center mode

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1125,11 +1125,15 @@
 
         if (_.options.centerMode === true && _.slideCount <= _.options.slidesToShow) {
             _.slideOffset = ((_.slideWidth * Math.floor(_.options.slidesToShow)) / 2) - ((_.slideWidth * _.slideCount) / 2);
+            verticalOffset = ((verticalHeight * Math.floor(_.options.slidesToShow)) / 2) - ((verticalHeight * _.slideCount) / 2);
         } else if (_.options.centerMode === true && _.options.infinite === true) {
             _.slideOffset += _.slideWidth * Math.floor(_.options.slidesToShow / 2) - _.slideWidth;
+            verticalOffset += verticalHeight * Math.floor(_.options.slidesToShow / 2) - verticalHeight;
         } else if (_.options.centerMode === true) {
             _.slideOffset = 0;
             _.slideOffset += _.slideWidth * Math.floor(_.options.slidesToShow / 2);
+            verticalOffset = 0;
+            verticalOffset += verticalHeight * Math.floor(_.options.slidesToShow / 2);
         }
 
         if (_.options.vertical === false) {


### PR DESCRIPTION
the calculation for the vertical items was missing if the slider was in center mode.  
Issue is shown here: http://jsfiddle.net/r3z30fLf/2/