### PR TITLE
Fixed blank space after the last slide on each carousel page with variableWidth: false

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2047,8 +2047,9 @@
         _.listHeight = _.$list.height();
 
 
+        var offset = _.$slides.first().outerWidth(true) - _.$slides.first().width();
         if (_.options.vertical === false && _.options.variableWidth === false) {
-            _.slideWidth = Math.ceil(_.listWidth / _.options.slidesToShow);
+            _.slideWidth = Math.ceil((_.listWidth + offset) / _.options.slidesToShow);
             _.$slideTrack.width(Math.ceil((_.slideWidth * _.$slideTrack.children('.slick-slide').length)));
 
         } else if (_.options.variableWidth === true) {
@@ -2058,7 +2059,6 @@
             _.$slideTrack.height(Math.ceil((_.$slides.first().outerHeight(true) * _.$slideTrack.children('.slick-slide').length)));
         }
 
-        var offset = _.$slides.first().outerWidth(true) - _.$slides.first().width();
         if (_.options.variableWidth === false) _.$slideTrack.children('.slick-slide').width(_.slideWidth - offset);
 
     };


### PR DESCRIPTION
Currently, if right margin is used in between the slides, this margin is visible after the last slide of the page in view. Slides' width calculation is done without account for this extra margin, resulting in smaller slides. The workaround is making carousel container bigger by this margin, which is inconvenient.

This fix adds offset for this last slide margin, so that combined width of all slides and margins on the current page (minus the last margin) is exactly same width as the container.