### PR TITLE
Allow slidesToScroll to work with swipeToSlide

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -529,7 +529,7 @@
             '<div class="slick-list"/>').parent();
         _.$slideTrack.css('opacity', 0);
 
-        if (_.options.centerMode === true || _.options.swipeToSlide === true) {
+        if (_.options.centerMode === true) {
             _.options.slidesToScroll = 1;
         }
 
@@ -729,12 +729,17 @@
 
     };
 
-    Slick.prototype.checkNavigable = function(index) {
+    Slick.prototype.checkNavigable = function(index, slidesToScroll) {
 
         var _ = this,
             navigables, prevNavigable;
 
-        navigables = _.getNavigableIndexes();
+
+        if (typeof slidesToScroll === 'undefined') {
+            slidesToScroll = _.options.slidesToScroll;
+        }
+
+        navigables = _.getNavigableIndexes(slidesToScroll);
         prevNavigable = 0;
         if (index > navigables[navigables.length - 1]) {
             index = navigables[navigables.length - 1];
@@ -1189,7 +1194,7 @@
 
     };
 
-    Slick.prototype.getNavigableIndexes = function() {
+    Slick.prototype.getNavigableIndexes = function(slidesToScroll) {
 
         var _ = this,
             breakPoint = 0,
@@ -1200,15 +1205,15 @@
         if (_.options.infinite === false) {
             max = _.slideCount;
         } else {
-            breakPoint = _.options.slidesToScroll * -1;
-            counter = _.options.slidesToScroll * -1;
+            breakPoint = slidesToScroll * -1;
+            counter = slidesToScroll * -1;
             max = _.slideCount * 2;
         }
 
         while (breakPoint < max) {
             indexes.push(breakPoint);
-            breakPoint = counter + _.options.slidesToScroll;
-            counter += _.options.slidesToScroll <= _.options.slidesToShow ? _.options.slidesToScroll : _.options.slidesToShow;
+            breakPoint = counter + slidesToScroll;
+            counter += slidesToScroll <= _.options.slidesToShow ? slidesToScroll : _.options.slidesToShow;
         }
 
         return indexes;
@@ -1300,7 +1305,7 @@
     Slick.prototype.initADA = function() {
         var _ = this,
                 numDotGroups = Math.ceil(_.slideCount / _.options.slidesToShow),
-                tabControlIndexes = _.getNavigableIndexes().filter(function(val) {
+                tabControlIndexes = _.getNavigableIndexes(_.options.slidesToScroll).filter(function(val) {
                     return (val >= 0) && (val < _.slideCount);
                 });
 
@@ -2680,7 +2685,7 @@
 
                     slideCount =
                         _.options.swipeToSlide ?
-                            _.checkNavigable( _.currentSlide + _.getSlideCount() ) :
+                            _.checkNavigable( _.currentSlide + _.getSlideCount(), 1 ) :
                             _.currentSlide + _.getSlideCount();
 
                     _.currentDirection = 0;
@@ -2692,7 +2697,7 @@
 
                     slideCount =
                         _.options.swipeToSlide ?
-                            _.checkNavigable( _.currentSlide - _.getSlideCount() ) :
+                            _.checkNavigable( _.currentSlide - _.getSlideCount(), 1 ) :
                             _.currentSlide - _.getSlideCount();
 
                     _.currentDirection = 1;


### PR DESCRIPTION
I needed slidesToScroll to work with swipeToSlide. This fiddle shows how enabling swipeToSlide causes the carousel to always use 1 for slidesToScroll:
http://jsfiddle.net/rmd0bczg/1/

My updated version allows swipeToSlide to work along with slidesToScroll:
http://jsfiddle.net/mq7chax1/6/