### PR TITLE
Fix .slick-current with aria-hidden=true issue.

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2343,6 +2343,7 @@
 
             _.$slides
                 .eq(index)
+                .addClass('slick-active')
                 .addClass('slick-center');
 
         } else {


### PR DESCRIPTION
I am working with slick[1.8.1] and accessibility things on a small project. When I turned `centerMode`  on / `infinite` off, the `.slick-current` element always has an `aria-hidden="true"` attribute.

```
$slides.slick({
    accessibility: true,
    centerMode: true,
    infinite: false,
    ...
});
```

I've checked the source code and found that the `activateADA` function turn the `aria-hidden` off for `.slick-active` but in the above case, the `.slick-current` is missing a `.slick-active` with it. 

Here is a demo for this bug: http://jsfiddle.net/r0an8476/5/