### PR TITLE
PATCH: Allows adaptiveHeight option with multiple slides shown.

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -246,8 +246,17 @@
 
     Slick.prototype.animateHeight = function() {
         var _ = this;
-        if (_.options.slidesToShow === 1 && _.options.adaptiveHeight === true && _.options.vertical === false) {
+        if (_.options.adaptiveHeight === true && _.options.vertical === false) {
             var targetHeight = _.$slides.eq(_.currentSlide).outerHeight(true);
+            if (_.options.slidesToShow > 1) {
+                var compHeight, i = 1;
+                for (i; i < _.options.slidesToShow; ++i) {
+                    compHeight = _.$slides.eq(_.currentSlide + i).outerHeight(true);
+                    if (compHeight > targetHeight) {
+                        targetHeight = compHeight;
+                    }
+                }
+            }
             _.$list.animate({
                 height: targetHeight
             }, _.options.speed);
@@ -2114,9 +2123,20 @@
 
         var _ = this;
 
-        if (_.options.slidesToShow === 1 && _.options.adaptiveHeight === true && _.options.vertical === false) {
+        if (_.options.adaptiveHeight === true && _.options.vertical === false) {
             var targetHeight = _.$slides.eq(_.currentSlide).outerHeight(true);
-            _.$list.css('height', targetHeight);
+            if (_.options.slidesToShow > 1) {
+                var compHeight, i = 1;
+                for (i; i < _.options.slidesToShow; ++i) {
+                    compHeight = _.$slides.eq(_.currentSlide + i).outerHeight(true);
+                    if (compHeight > targetHeight) {
+                        targetHeight = compHeight;
+                    }
+                }
+            }
+            _.$list.animate({
+                height: targetHeight
+            }, _.options.speed);
         }
 
     };


### PR DESCRIPTION
The current carousel implementation of adaptiveHeight only works for single-slide carousels. [[fiddle](http://jsfiddle.net/ebaker/zvxmd8Ld/3/)]

This patch allows for multiple slides, adapting to the height of the tallest item. [[fiddle](http://jsfiddle.net/ebaker/h5v0dppe/15/)]