### PR TITLE
Add a custom callback for the aria-label of the paging dots 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -81,6 +81,7 @@ centerMode | boolean | false | Enables centered view with partial prev/next slid
 centerPadding | string | '50px' | Side padding when in center mode. (px or %)
 cssEase | string |  'ease' | CSS3 easing
 customPaging | function | n/a | Custom paging templates. See source for use example.
+customPagingADALabel | function | n/a | Custom aria-label for paging dots. See source for use example.
 dots | boolean | false | Current slide indicator dots
 dotsClass | string | 'slick-dots' | Class for slide indicator dots container
 draggable | boolean | true | Enables desktop dragging

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -54,6 +54,9 @@
                 customPaging: function(slider, i) {
                     return $('<button type="button" />').text(i + 1);
                 },
+                customPagingADALabel: function(slider, i, numDotGroups, slide) {
+                    return i + ' of ' + numDotGroups;
+                },
                 dots: false,
                 dotsClass: 'slick-dots',
                 draggable: true,
@@ -1368,7 +1371,7 @@
                     'role': 'tab',
                     'id': 'slick-slide-control' + _.instanceUid + i,
                     'aria-controls': 'slick-slide' + _.instanceUid + mappedSlideIndex,
-                    'aria-label': (i + 1) + ' of ' + numDotGroups,
+                    'aria-label': _.options.customPagingADALabel.call(this, _, (i + 1), numDotGroups, _.$slides[mappedSlideIndex]),
                     'aria-selected': null,
                     'tabindex': '-1'
                 });


### PR DESCRIPTION
Hello,

This PR adds a callback so the `aria-label` on the dots can be customized / changed.

This resolves #3137.

(Note: The slide is also passed to the callback to allow for additional information to be added to the label. An example use case for this: we have an accessibility to include in the alt text for the image within the slide in the `aria-label` of the dot).