### PR TITLE
Fix initial state offset calculation

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1103,6 +1103,7 @@
         if (_.options.infinite === true) {
             if (_.slideCount > _.options.slidesToShow) {
                 _.slideOffset = (_.slideWidth * _.options.slidesToShow) * -1;
+                _.slideOffset = _.slideOffset - (_.slideWidth * (_.options.slidesToShow - Math.floor(_.options.slidesToShow)));
                 coef = -1
 
                 if (_.options.vertical === true && _.options.centerMode === true) {


### PR DESCRIPTION
Fix initial state offset calculation when slidesToShow is float value and infinite set as true.
[Bad behavior example](http://jsfiddle.net/vdiachenko/ey60187d/5/).