### PR TITLE
Do not set slidesToScroll when centerMode is true.

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -529,7 +529,7 @@
             '<div class="slick-list"/>').parent();
         _.$slideTrack.css('opacity', 0);
 
-        if (_.options.centerMode === true || _.options.swipeToSlide === true) {
+        if (_.options.swipeToSlide === true) {
             _.options.slidesToScroll = 1;
         }
 


### PR DESCRIPTION
Resolves https://github.com/kenwheeler/slick/issues/2328.