### PR TITLE
allow scrolling to first or last slide when slidesToScroll is greater than the number of remaining slides

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2514,25 +2514,18 @@
             _.asNavFor(index);
         }
 
+        if (_.options.infinite === false) {
+            index = Math.min(index, _.getDotCount() * _.options.slidesToScroll);
+            index = Math.max(index, 0);
+        }
+
         targetSlide = index;
         targetLeft = _.getLeft(targetSlide);
         slideLeft = _.getLeft(_.currentSlide);
 
         _.currentLeft = _.swipeLeft === null ? slideLeft : _.swipeLeft;
 
-        if (_.options.infinite === false && _.options.centerMode === false && (index < 0 || index > _.getDotCount() * _.options.slidesToScroll)) {
-            if (_.options.fade === false) {
-                targetSlide = _.currentSlide;
-                if (dontAnimate !== true && _.slideCount > _.options.slidesToShow) {
-                    _.animateSlide(slideLeft, function() {
-                        _.postSlide(targetSlide);
-                    });
-                } else {
-                    _.postSlide(targetSlide);
-                }
-            }
-            return;
-        } else if (_.options.infinite === false && _.options.centerMode === true && (index < 0 || index > (_.slideCount - _.options.slidesToScroll))) {
+        if (_.options.infinite === false && _.currentSlide === index && (index === 0 || index === _.getDotCount() * _.options.slidesToScroll)) {
             if (_.options.fade === false) {
                 targetSlide = _.currentSlide;
                 if (dontAnimate !== true && _.slideCount > _.options.slidesToShow) {


### PR DESCRIPTION
Example:

Try scrolling to either the first or last slide:

Current behavior: https://jsfiddle.net/caseyjhol/crkfxnvo/1/
New behavior: https://jsfiddle.net/caseyjhol/yh72sojv/1/

Fixes #3061.

It seems to me, although I might be missing something, that calling `_.postSlide` is unnecessary if the slide won't be changing position again. In my testing with lines 2529-2538 removed, I noticed no difference in behavior.