### PR TITLE
Bugfix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false
+
+[*.html]
+indent_size = 2

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2419,15 +2419,13 @@
     Slick.prototype.setupInfinite = function() {
 
         var _ = this,
-            i, slideIndex, infiniteCount;
+            i, infiniteCount;
 
         if (_.options.fade === true) {
             _.options.centerMode = false;
         }
 
         if (_.options.infinite === true && _.options.fade === false) {
-
-            slideIndex = null;
 
             if (_.slideCount > _.options.slidesToShow) {
 
@@ -2437,22 +2435,27 @@
                     infiniteCount = _.options.slidesToShow;
                 }
 
-                for (i = _.slideCount; i > (_.slideCount -
-                        infiniteCount); i -= 1) {
-                    slideIndex = i - 1;
-                    $(_.$slides[slideIndex]).clone(true).attr('id', '')
-                        .attr('data-slick-index', slideIndex - _.slideCount)
-                        .prependTo(_.$slideTrack).addClass('slick-cloned');
+                for (i = 0; i < _.slideCount; i++) {
+
+                    if (i >= _.slideCount - infiniteCount) {
+                        $(_.$slides[i])
+                            .clone(true)
+                            .attr('id', '')
+                            .attr('data-slick-index', i - _.slideCount)
+                            .insertBefore(_.$slides[0])
+                            .addClass('slick-cloned');
+                    }
+
+                    if (i < _.slideCount) {
+                        $(_.$slides[i])
+                            .clone(true)
+                            .attr('id', '')
+                            .attr('data-slick-index', i + _.slideCount)
+                            .appendTo(_.$slideTrack)
+                            .addClass('slick-cloned');
+                    }
+
                 }
-                for (i = 0; i < infiniteCount  + _.slideCount; i += 1) {
-                    slideIndex = i;
-                    $(_.$slides[slideIndex]).clone(true).attr('id', '')
-                        .attr('data-slick-index', slideIndex + _.slideCount)
-                        .appendTo(_.$slideTrack).addClass('slick-cloned');
-                }
-                _.$slideTrack.find('.slick-cloned').find('[id]').each(function() {
-                    $(this).attr('id', '');
-                });
 
             }
 

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2419,7 +2419,43 @@
     Slick.prototype.setupInfinite = function() {
 
         var _ = this,
-            i, infiniteCount;
+            i, infiniteCount, curSlide;
+
+        var copyCanvasData = function(slide, clone) {
+            var canvases = slide.find('canvas');
+            var cloneCanvases = clone.find('canvas');
+
+            cloneCanvases.each(function(index, cloneCanvas) {
+                var canvas = canvases[index];
+                var ctx = canvas.getContext('2d');
+                var cloneCtx = cloneCanvas.getContext('2d');
+                var imageData = ctx.getImageData(
+                    0,
+                    0,
+                    canvas.width, canvas.height
+                );
+
+                cloneCtx.putImageData(imageData, 0, 0);
+            });
+        };
+
+        var createClone = function(slide, index, doPrepend) {
+            var clone = slide.clone(true);
+
+            clone
+                .attr('id', '')
+                .attr('data-slick-index', index)
+                .insertBefore(_.$slides[0])
+                .addClass('slick-cloned');
+
+            copyCanvasData(slide, clone);
+
+            if (doPrepend) {
+                clone.insertBefore(_.$slides[0]);
+            } else {
+                clone.appendTo(_.$slideTrack);
+            }
+        };
 
         if (_.options.fade === true) {
             _.options.centerMode = false;
@@ -2437,23 +2473,13 @@
 
                 for (i = 0; i < _.slideCount; i++) {
 
+                    curSlide = $(_.$slides[i]);
+
                     if (i >= _.slideCount - infiniteCount) {
-                        $(_.$slides[i])
-                            .clone(true)
-                            .attr('id', '')
-                            .attr('data-slick-index', i - _.slideCount)
-                            .insertBefore(_.$slides[0])
-                            .addClass('slick-cloned');
+                        createClone(curSlide, i - _.slideCount, true);
                     }
 
-                    if (i < _.slideCount) {
-                        $(_.$slides[i])
-                            .clone(true)
-                            .attr('id', '')
-                            .attr('data-slick-index', i + _.slideCount)
-                            .appendTo(_.$slideTrack)
-                            .addClass('slick-cloned');
-                    }
+                    createClone(curSlide, i + _.slideCount, false);
 
                 }
 


### PR DESCRIPTION
This pull request fixes an issue where infinite scroll does not account for `canvas` elements in a slide. Scrolling beyond the last slide (or first slide) results in an empty `canvas` until the carousel snaps back.

This problem is caused by the jQuery `clone()` method (and the native JS `clone()` method), because they do not copy image data from within a `canvas` element.

See http://jsfiddle.net/aL8gszo4/ for a demo of the bug.