### PR TITLE
adding event.cancelable to prevent chrome passive event errors

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2824,7 +2824,7 @@
 
         swipeDirection = _.swipeDirection();
 
-        if (event.originalEvent !== undefined && _.touchObject.swipeLength > 4) {
+        if (event.originalEvent !== undefined && _.touchObject.swipeLength > 4 && event.cancelable) {
             _.swiping = true;
             event.preventDefault();
         }


### PR DESCRIPTION
http://jsfiddle.net/6fhegb8o/2/

Issue is only on android webviews, load the fiddle page in chrome browser on android and the swipe the cards, you will see error 
**[Intervention] Ignored attempt to cancel a touchmove event with cancelable=false, for example because scrolling is in progress and cannot be interrupted.** in console

Tested with the fix on IOS, ANDROID and desktop browsers