### PR TITLE
Allow the 'appendDots' option to work with multiple elements properly

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -496,7 +496,7 @@
 
             _.$dots = dot.appendTo(_.options.appendDots);
 
-            _.$dots.find('li').first().addClass('slick-active');
+            _.$dots.find('li:first-child').addClass('slick-active');
 
         }
 
@@ -2989,8 +2989,7 @@
                     .end();
 
             _.$dots
-                .find('li')
-                .eq(Math.floor(_.currentSlide / _.options.slidesToScroll))
+                .find('li:nth-child(' + (Math.floor(_.currentSlide / _.options.slidesToScroll) + 1) + ')')
                 .addClass('slick-active');
 
         }


### PR DESCRIPTION
Using 'appendDots' like this:
`appendDots: $('.dots')`
where there's multiple .dots elements or something like this:
`appendDots: $('.dots-1, .dots-2')`

The existing implementation already populated multiple dot containers and would change to the correct slide when they were clicked but it wasn't setting the .slick-active class on the appropriate li in each of the dot containers.

This change swaps jQuery's .eq() method for CSS :nth-child() so that it'll put .slick-active on the appropriate li in each dot container.