### PR TITLE
fix: prevent cache deletion on breakpoints refresh

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1002,7 +1002,7 @@
 
             _.$slideTrack.children(this.options.slide).detach();
 
-            _.$slidesCache.filter(filter).appendTo(_.$slideTrack);
+            _.$slidesCache.clone(true, true).filter(filter).appendTo(_.$slideTrack);
 
             _.reinit();
 


### PR DESCRIPTION
When we use both filter & breakpoints check, cache elements appended to slider could be deleted accidently while refresh function.