### PR TITLE
Update slick.js

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1599,11 +1599,11 @@
 
         if (_.options.centerMode === true) {
             if (_.options.infinite === true) {
-                rangeStart = _.currentSlide + (_.options.slidesToShow / 2 + 1);
+                rangeStart = _.currentSlide + Math.floor(_.options.slidesToShow / 2 + 1);
                 rangeEnd = rangeStart + _.options.slidesToShow + 2;
             } else {
-                rangeStart = Math.max(0, _.currentSlide - (_.options.slidesToShow / 2 + 1));
-                rangeEnd = 2 + (_.options.slidesToShow / 2 + 1) + _.currentSlide;
+                rangeStart = Math.max(0, _.currentSlide - Math.floor(_.options.slidesToShow / 2 + 1));
+                rangeEnd = 2 + Math.ceil(_.options.slidesToShow / 2 + 1) + _.currentSlide;
             }
         } else {
             rangeStart = _.options.infinite ? _.options.slidesToShow + _.currentSlide : _.currentSlide;


### PR DESCRIPTION
added Math.floor and Match.ceil in lines #1601, #1604, #1605 to avoid 'floatingpoint-result' which caused a bug in lazyload