### PR TITLE
Clone originalSlides in cleanUpRows to keep registered events

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -822,7 +822,8 @@
         var _ = this, originalSlides;
 
         if(_.options.rows > 0) {
-            originalSlides = _.$slides.children().children();
+            // Get the original slides and clone them to prevent the events from being removed in empty() call below:
+            originalSlides = _.$slides.children().children().clone(true, true);
             originalSlides.removeAttr('style');
             _.$slider.empty().append(originalSlides);
         }


### PR DESCRIPTION
When using unslick in combination with registered events (e.g. click on a slicked children element) even with jQuery .on() the events are removed. The reason is that empty() kills the events from the children before they are appended. By cloning them before, we keep the events. An example real world use case would be a modal registered on a slick element which doesn't work after unslicking anymore.