### PR TITLE
Small performance optimization

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2807,11 +2807,9 @@
         _.touchObject.curX = touches !== undefined ? touches[0].pageX : event.clientX;
         _.touchObject.curY = touches !== undefined ? touches[0].pageY : event.clientY;
 
-        _.touchObject.swipeLength = Math.round(Math.sqrt(
-            Math.pow(_.touchObject.curX - _.touchObject.startX, 2)));
+        _.touchObject.swipeLength = Math.abs(_.touchObject.curX - _.touchObject.startX);
 
-        verticalSwipeLength = Math.round(Math.sqrt(
-            Math.pow(_.touchObject.curY - _.touchObject.startY, 2)));
+        verticalSwipeLength = Math.abs(_.touchObject.curY - _.touchObject.startY);
 
         if (!_.options.verticalSwiping && !_.swiping && verticalSwipeLength > 4) {
             _.scrolling = true;


### PR DESCRIPTION
We dont need to use Round(Sqrt(Pow(x1 - x2, 2))) to get length. It will be valid for x-y space but on x-x it's odd