### PR TITLE
fix(SlickCarousel): enable prev call to slide to 0th index

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2514,6 +2514,11 @@
             _.asNavFor(index);
         }
 
+        if(_.options.infinite === false && index < 0) {
+          _.currentSlide = 0;
+          _.updateArrows();
+        }
+
         targetSlide = index;
         targetLeft = _.getLeft(targetSlide);
         slideLeft = _.getLeft(_.currentSlide);


### PR DESCRIPTION
The Carousel has a bug where clicking on the previous arrow will not cause the slider to display previous slides. This leads to a poor and confusing user experience.

This can be reproduced using the following steps on [this fiddle](https://jsfiddle.net/gsirius/gt4bxowe/):

1. Click on the 2nd slide (or any slide whose index >= 1)
2. Click on the previous arrow

You will see that the previous slides are no longer visible, leaving the user unable to see any previous slides. 

The user can only use the previous arrow when the current index >`slidesToScroll`. For example, if the user clicks the 6th slide and then clicks the previous arrow, the Carousel will return to its position at the 0th index.

This is happening because `_.currentIndex` is not being set to the new index before the Carousel internals execute a CSS transition to a previous slide. The call to `animateSlide`:

https://github.com/UrbanDoor/slick/blob/905114f3dc5c86e3078e90c720151c6f6478f1e1/slick/slick.js#L2532-L2534

will attempt to set the Carousel to a previous slide, but the callback to `_.postSlide` yields a call to `_.setPosition` that calculates the slider CSS based on the `_.currentIndex`, which has not been set to the `targetIndex` but remains at the index selected before the previous arrow was clicked:

https://github.com/UrbanDoor/slick/blob/905114f3dc5c86e3078e90c720151c6f6478f1e1/slick/slick.js#L2532-L2534

This PR checks to see that when a Carousel with no infinite scroll has a new index is negative, the current slide will be set the 0th index so that the previous arrow will work as a user might expect.

See [this fiddle](https://jsfiddle.net/gsirius/por3wze6/1/) to see a working version of the app. This fiddle sources the JS from a [CDN](https://rawcdn.githack.com/SashaBayan/slick/b3755619bd96fd91cf57c7f44c233a99017e2e66/slick/slick.js) sourced from my fork.