### PR TITLE
Fixes flicker at the end of rotation

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -325,7 +325,7 @@
                         _.disableTransition();
 
                         callback.call();
-                    }, _.options.speed);
+                    }, _.options.speed * 1.5);
                 }
 
             }


### PR DESCRIPTION
Fixes #1890 

It looks like the flicker was caused by 2 transitions applied at the same time. Spacing them out seems to fix the flicker.

Not sure what other side effects this may have, though.