### PR TITLE
Update aria-selected to a valid value

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1369,7 +1369,7 @@
                     'id': 'slick-slide-control' + _.instanceUid + i,
                     'aria-controls': 'slick-slide' + _.instanceUid + mappedSlideIndex,
                     'aria-label': (i + 1) + ' of ' + numDotGroups,
-                    'aria-selected': null,
+                    'aria-selected': 'false',
                     'tabindex': '-1'
                 });
 


### PR DESCRIPTION
`aria-selected` only allows `true`, `false` or `undefined`. This makes null an invalid value for it.
https://www.w3.org/WAI/PF/aria/states_and_properties#aria-selected