### PR TITLE
Set font-display: auto on slick-theme.css

### DIFF
--- a/slick/slick-theme.css
+++ b/slick/slick-theme.css
@@ -11,6 +11,7 @@
     font-family: 'slick';
     font-weight: normal;
     font-style: normal;
+    font-display: auto;
 
     src: url('./fonts/slick.eot');
     src: url('./fonts/slick.eot?#iefix') format('embedded-opentype'), url('./fonts/slick.woff') format('woff'), url('./fonts/slick.ttf') format('truetype'), url('./fonts/slick.svg#slick') format('svg');


### PR DESCRIPTION
This PR simply adds `font-display: auto` to the webfont:

Read more about font-display here:
https://developers.google.com/web/updates/2016/02/font-display

And here:
https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display