### PR TITLE
Fix: Cursor hand to grab

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+*.scss
+*.less
+*.css

--- a/slick/slick.css
+++ b/slick/slick.css
@@ -32,10 +32,12 @@
 {
     outline: none;
 }
-.slick-list.dragging
-{
+.slick-list.draggable {
     cursor: pointer;
     cursor: grab;
+}
+.slick-list.dragging {
+    cursor: grabbing;
 }
 
 .slick-slider .slick-track,

--- a/slick/slick.css
+++ b/slick/slick.css
@@ -35,7 +35,7 @@
 .slick-list.dragging
 {
     cursor: pointer;
-    cursor: hand;
+    cursor: grab;
 }
 
 .slick-slider .slick-track,

--- a/slick/slick.less
+++ b/slick/slick.less
@@ -27,7 +27,7 @@
 
     &.dragging {
         cursor: pointer;
-        cursor: hand;
+        cursor: grab;
     }
 }
 .slick-slider .slick-track,

--- a/slick/slick.less
+++ b/slick/slick.less
@@ -25,9 +25,13 @@
         outline: none;
     }
 
-    &.dragging {
+    &.draggable {
         cursor: pointer;
         cursor: grab;
+    }
+    
+    &.dragging {
+        cursor: grabbing;
     }
 }
 .slick-slider .slick-track,

--- a/slick/slick.scss
+++ b/slick/slick.scss
@@ -25,9 +25,13 @@
         outline: none;
     }
 
-    &.dragging {
+    &.draggable {
         cursor: pointer;
         cursor: grab;
+    }
+
+    &.dragging {
+        cursor: grabbing;
     }
 }
 .slick-slider .slick-track,

--- a/slick/slick.scss
+++ b/slick/slick.scss
@@ -27,7 +27,7 @@
 
     &.dragging {
         cursor: pointer;
-        cursor: hand;
+        cursor: grab;
     }
 }
 .slick-slider .slick-track,


### PR DESCRIPTION
Resolves issue: https://github.com/kenwheeler/slick/issues/3355

 ### Description
Removed  **Cursor: hand;**
Added **Cursor: grab;** and **Cursor: grabbing;** 

However I'm unsure if dragging class is being toggled at all so it may be fine to remove that .slick-list.dragging style. Let me know if that is the case.

### Demo
http://jsfiddle.net/devshaun/fr8kgzwo/