### PR TITLE
fixed nested child carousel sending keyboard events to parent carousel

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1522,12 +1522,14 @@
          //Dont slide if the cursor is inside the form fields and arrow keys are pressed
         if(!event.target.tagName.match('TEXTAREA|INPUT|SELECT')) {
             if (event.keyCode === 37 && _.options.accessibility === true) {
+                event.stopPropagation();
                 _.changeSlide({
                     data: {
                         message: _.options.rtl === true ? 'next' :  'previous'
                     }
                 });
             } else if (event.keyCode === 39 && _.options.accessibility === true) {
+                event.stopPropagation();
                 _.changeSlide({
                     data: {
                         message: _.options.rtl === true ? 'previous' : 'next'


### PR DESCRIPTION
In a situation where we have nested carousels, this fixes a bug I experienced where tapping the left arrow key was causing the parent carousel to change slides.

This is similar to [this PR](https://github.com/kenwheeler/slick/pull/2576) except that one is for click events and this one is for keyboard events.

This fiddle shows the problem in action. When you see the nested carousel, click the second dot then click the left arrow. The parent carousel will go back one slide instead of the child carousel.
https://jsfiddle.net/fhuy30tb/