### PR TITLE
Fix #3560

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2354,7 +2354,7 @@
                 if (index === 0) {
 
                     allSlides
-                        .eq(allSlides.length - 1 - _.options.slidesToShow)
+                        .eq( _.options.slidesToShow + _.slideCount + 1 )
                         .addClass('slick-center');
 
                 } else if (index === _.slideCount - 1) {


### PR DESCRIPTION
This is happening when number of items is not an even number.

When applying CSS transitions, slider is not running smoothly if it goes forward (from last to first slide). Works fine when going backwards (From first to last slide). Expected behavior: CSS transitions should run smoothly on both ways.

Without fix:
https://jsfiddle.net/explorador/y7r3p2nx/12/

With fix:
https://jsfiddle.net/explorador/dfs6gok3/11/