### PR TITLE
Fix #3426

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -559,7 +559,7 @@
         newSlides = document.createDocumentFragment();
         originalSlides = _.$slider.children();
 
-        if(_.options.rows > 0) {
+        if(_.options.rows > 1) {
 
             slidesPerSection = _.options.slidesPerRow * _.options.rows;
             numOfSlides = Math.ceil(


### PR DESCRIPTION
This fixes #3426 in my tests, but I don't know what other implications it might have. Data attributes were not being passed to the custom pager function.

This reverts a change from https://github.com/kenwheeler/slick/commit/34612b42641e8fd4250f70666a8da67eb624d002 which (apparently) fixed a bug with multiple rows.

Issue:
https://jsfiddle.net/drdogbot7/673w190p/

Fix:
http://jsfiddle.net/drdogbot7/h3b2jvgq/