### PR TITLE
Adds fix to prevent infinite loop in buildRows

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -559,7 +559,7 @@
         newSlides = document.createDocumentFragment();
         originalSlides = _.$slider.children();
 
-        if(_.options.rows > 0) {
+        if(_.options.rows > 0 && _.options.slidesPerRow > 0) {
 
             slidesPerSection = _.options.slidesPerRow * _.options.rows;
             numOfSlides = Math.ceil(


### PR DESCRIPTION
closes #3823 

Slick goes into into an infinite loop when the *slidesPerRow* option is set as 0.

This is demonstrated here -

https://jsfiddle.net/bomoko/ybqa8gtj/12/

The fix in this PR is demonstrated here

https://jsfiddle.net/bomoko/45st2Luy/6/
