### PR TITLE
Add font-display fallback 

### DIFF
--- a/slick/slick-theme.css
+++ b/slick/slick-theme.css
@@ -11,6 +11,7 @@
     font-family: 'slick';
     font-weight: normal;
     font-style: normal;
+    font-display: fallback;
 
     src: url('./fonts/slick.eot');
     src: url('./fonts/slick.eot?#iefix') format('embedded-opentype'), url('./fonts/slick.woff') format('woff'), url('./fonts/slick.ttf') format('truetype'), url('./fonts/slick.svg#slick') format('svg');

--- a/slick/slick-theme.less
+++ b/slick/slick-theme.less
@@ -68,6 +68,7 @@
             font-family: 'slick';
             font-weight: normal;
             font-style: normal;
+            font-display: fallback;
             src: url('@{slick-font-path}slick.eot');
             src: url('@{slick-font-path}slick.eot?#iefix') format('embedded-opentype'), url('@{slick-font-path}slick.woff') format('woff'), url('@{slick-font-path}slick.ttf') format('truetype'), url('@{slick-font-path}slick.svg#slick') format('svg');
         }

--- a/slick/slick-theme.scss
+++ b/slick/slick-theme.scss
@@ -55,6 +55,7 @@ $slick-opacity-not-active: 0.25 !default;
         src: slick-font-url("slick.eot?#iefix") format("embedded-opentype"), slick-font-url("slick.woff") format("woff"), slick-font-url("slick.ttf") format("truetype"), slick-font-url("slick.svg#slick") format("svg");
         font-weight: normal;
         font-style: normal;
+        font-display: fallback;
     }
 }
 


### PR DESCRIPTION
According to lighthouse advice, adding font-display feature
cf. https://developers.google.com/web/updates/2016/02/font-display?utm_source=lighthouse&utm_medium=devtools