### PR TITLE
[kenwheeler/slick#3691] Fix extra cloned slides

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2444,7 +2444,7 @@
                         .attr('data-slick-index', slideIndex - _.slideCount)
                         .prependTo(_.$slideTrack).addClass('slick-cloned');
                 }
-                for (i = 0; i < infiniteCount  + _.slideCount; i += 1) {
+                for (i = 0; i < infiniteCount; i += 1) {
                     slideIndex = i;
                     $(_.$slides[slideIndex]).clone(true).attr('id', '')
                         .attr('data-slick-index', slideIndex + _.slideCount)


### PR DESCRIPTION
When infinite is enabled, the loop that generates the cloned slides to be appended to the end of the track iterates over too many slides. In fact it iterates beyond the number of slides but jQuery fails silently once it exceeds the slides. The result is that too many slides get cloned and appended to the end of the track. This previously caused issues fixed with [kenwheeler/slick#3809]. This remaining fix cleans up the DOM by trimming out the cloned slides that are never visible.

Original Issue:
http://jsfiddle.net/MrCroissant1/xrgkL8nu/4/

![Screenshot at Sep 06 17-29-55](https://user-images.githubusercontent.com/6515313/64461752-078b8280-d0cc-11e9-8708-401810cd08a6.png)
Notice how all the slides from the slider are cloned as the end of the track

With fix:
http://jsfiddle.net/MrCroissant1/79yunkeq/1/

![Screenshot at Sep 06 17-43-02](https://user-images.githubusercontent.com/6515313/64462257-d14f0280-d0cd-11e9-88b0-6e2586135749.png)
Notice how only the first slide is cloned at the end of the slide, which is all we need since slidesToShow is just 1.
