### PR TITLE
add single classes to slick-dots children

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -491,7 +491,7 @@
             dot = $('<ul />').addClass(_.options.dotsClass);
 
             for (i = 0; i <= _.getDotCount(); i += 1) {
-                dot.append($('<li />').append(_.options.customPaging.call(this, _, i)));
+                dot.append($('<li />').addClass('slick-dot').append(_.options.customPaging.call(this, _, i)));
             }
 
             _.$dots = dot.appendTo(_.options.appendDots);
@@ -1019,7 +1019,7 @@
             .off('focus.slick blur.slick')
             .on(
                 'focus.slick',
-                '*', 
+                '*',
                 function(event) {
                     var $sf = $(this);
 
@@ -1034,7 +1034,7 @@
                 }
             ).on(
                 'blur.slick',
-                '*', 
+                '*',
                 function(event) {
                     var $sf = $(this);
 
@@ -1366,6 +1366,7 @@
 
                 $(this).find('button').first().attr({
                     'role': 'tab',
+                    'class': 'slick-slide-control',
                     'id': 'slick-slide-control' + _.instanceUid + i,
                     'aria-controls': 'slick-slide' + _.instanceUid + mappedSlideIndex,
                     'aria-label': (i + 1) + ' of ' + numDotGroups,


### PR DESCRIPTION
Hi Ken,

Gotta say, I love slick. 
Thank your for all your work on this!

I noticed most elements have classes to style but the slick dots are the only ones left by the wayside.
This pull request adds single classes that follow the current naming convention in place to both `.slick-dot li` and `.slick-dot button`. My editor then trimmed trailing whitespace along lines 1022 and 1037.

Sincerely,
Bryan Stoner