### PR TITLE
Update jsDelivr CDN links

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -23,15 +23,15 @@ Just add a link to the css file in your `<head>`:
 
 ```html
 <!-- Add the slick-theme.css if you want default styling -->
-<link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/gh/kenwheeler/slick@1.8.1/slick/slick.css"/>
+<link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css"/>
 <!-- Add the slick-theme.css if you want default styling -->
-<link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/gh/kenwheeler/slick@1.8.1/slick/slick-theme.css"/>
+<link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick-theme.css"/>
 ```
 
 Then, before your closing ```<body>``` tag add:
 
 ```html
-<script type="text/javascript" src="//cdn.jsdelivr.net/gh/kenwheeler/slick@1.8.1/slick/slick.min.js"></script>
+<script type="text/javascript" src="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
 ```
 
 #### Package Managers


### PR DESCRIPTION
Hey, Martin from jsDelivr here.

Following a discussion on [Twitter](https://twitter.com/jsDelivr/status/1194721036132081664), I noticed you currently list npm-based links on your website and GitHub-based links in the README. This PR updates the README to use the npm-based links, which will improve cache hits for the end-users and give you more precise download stats since the two are considered separate projects.