### PR TITLE
Fix: wait for animate bug

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -320,7 +320,11 @@
                 _.$slideTrack.css(animProps);
 
                 if (callback) {
-                    setTimeout(function() {
+                    if (_.currentTimeout) {
+                        clearTimeout(_.currentTimeout);
+                    }
+                    _.currentTimeout = setTimeout(function() {
+                        _.currentTimeout = null;
 
                         _.disableTransition();
 
@@ -1019,7 +1023,7 @@
             .off('focus.slick blur.slick')
             .on(
                 'focus.slick',
-                '*', 
+                '*',
                 function(event) {
                     var $sf = $(this);
 
@@ -1034,7 +1038,7 @@
                 }
             ).on(
                 'blur.slick',
-                '*', 
+                '*',
                 function(event) {
                     var $sf = $(this);
 


### PR DESCRIPTION
When `waitForAnimate` is set to `false`, if you trigger multiple consecutive navigations, you see a glitch at the end of the animation (the CSS transition is cleared by the first animation callback, while the last animation is still running).  
This makes sure that only the last callback is executed.  

Without fix:
http://jsfiddle.net/xidi2xidi/yzn9v5ej/6/

With fix:
http://jsfiddle.net/xidi2xidi/xkwgjd8e/1/

Closes #607 #1737 #2401