### PR TITLE
Supporting nested sliders

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -103,6 +103,7 @@ responsive | array | null | Array of objects [containing breakpoints and setting
 rows | int | 1 | Setting this to more than 1 initializes grid mode. Use slidesPerRow to set how many slides should be in each row.
 rtl | boolean | false | Change the slider's direction to become right-to-left
 slide | string | '' | Slide element query
+sliderContainer | string | '' | Query to locate the container of the slides. Defaults to the slider itself.
 slidesPerRow | int | 1 | With grid mode initialized via the rows option, this sets how many slides are in each grid row.
 slidesToScroll | int | 1 | # of slides to scroll at a time
 slidesToShow | int | 1 | # of slides to show at a time

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -74,6 +74,7 @@
                 rows: 1,
                 rtl: false,
                 slide: '',
+                sliderContainer: '',
                 slidesPerRow: 1,
                 slidesToShow: 1,
                 slidesToScroll: 1,
@@ -159,6 +160,8 @@
                 _.hidden = 'webkitHidden';
                 _.visibilityChange = 'webkitvisibilitychange';
             }
+
+            _.$sliderContainer = _.options.sliderContainer ? $(element).find(_.options.sliderContainer) : $(element);
 
             _.autoPlay = $.proxy(_.autoPlay, _);
             _.autoPlayClear = $.proxy(_.autoPlayClear, _);
@@ -507,7 +510,7 @@
         var _ = this;
 
         _.$slides =
-            _.$slider
+            _.$sliderContainer
                 .children( _.options.slide + ':not(.slick-cloned)')
                 .addClass('slick-slide');
 
@@ -557,7 +560,7 @@
         var _ = this, a, b, c, newSlides, numOfSlides, originalSlides,slidesPerSection;
 
         newSlides = document.createDocumentFragment();
-        originalSlides = _.$slider.children();
+        originalSlides = _.$sliderContainer.children();
 
         if(_.options.rows > 0) {
 
@@ -581,8 +584,8 @@
                 newSlides.appendChild(slide);
             }
 
-            _.$slider.empty().append(newSlides);
-            _.$slider.children().children().children()
+            _.$sliderContainer.empty().append(newSlides);
+            _.$sliderContainer.children().children().children()
                 .css({
                     'width':(100 / _.options.slidesPerRow) + '%',
                     'display': 'inline-block'
@@ -824,7 +827,7 @@
         if(_.options.rows > 0) {
             originalSlides = _.$slides.children().children();
             originalSlides.removeAttr('style');
-            _.$slider.empty().append(originalSlides);
+            _.$sliderContainer.empty().append(originalSlides);
         }
 
     };
@@ -898,7 +901,7 @@
 
             _.$list.detach();
 
-            _.$slider.append(_.$slides);
+            _.$sliderContainer.append(_.$slides);
         }
 
         _.cleanUpRows();


### PR DESCRIPTION
This pull request introduces a new setting, allowing to handle the following use cases:
```html
<div class="slick">
  <div class="intermediary-element">
    <div class="slick-slide"></div>
    <div class="slick-slide"></div>
    <div class="slick-slide"></div>
  </div>
</div>
```

By making use of the new option

```js
$('.slick').slick({
    sliderContainer: '.intermediary-element'
});
```