### PR TITLE
Fix bug where single row slider is still generating extra row markup

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -71,7 +71,7 @@
                 pauseOnDotsHover: false,
                 respondTo: 'window',
                 responsive: null,
-                rows: 1,
+                rows: 0,
                 rtl: false,
                 slide: '',
                 slidesPerRow: 1,
@@ -559,7 +559,7 @@
         newSlides = document.createDocumentFragment();
         originalSlides = _.$slider.children();
 
-        if(_.options.rows > 0) {
+        if(_.options.rows > 1) {
 
             slidesPerSection = _.options.slidesPerRow * _.options.rows;
             numOfSlides = Math.ceil(
@@ -570,6 +570,9 @@
                 var slide = document.createElement('div');
                 for(b = 0; b < _.options.rows; b++) {
                     var row = document.createElement('div');
+                    
+                    row.classList.add('slick-row');
+                    
                     for(c = 0; c < _.options.slidesPerRow; c++) {
                         var target = (a * slidesPerSection + ((b * _.options.slidesPerRow) + c));
                         if (originalSlides.get(target)) {
@@ -821,7 +824,7 @@
 
         var _ = this, originalSlides;
 
-        if(_.options.rows > 0) {
+        if(_.options.rows > 1) {
             originalSlides = _.$slides.children().children();
             originalSlides.removeAttr('style');
             _.$slider.empty().append(originalSlides);


### PR DESCRIPTION
Fixed options check to ensure extra row markup only gets created where there is more than 1 row.

Added extra class to the row element to make its purpose less ambiguous.


For several years now, I've noticed that a single row slider still generates this extra markup. Since the markup is just an empty div, its purpose is not exactly clear and thus has tripped up several developers I've spoken with.

Since the default row value is 1, this seems like a simple and appropriate change to make the option work as expected and have the resulting markup be more clear for the developer. 