### PR TITLE
Accessibility: remove outline: none from themes

### DIFF
--- a/slick/slick-theme.css
+++ b/slick/slick-theme.css
@@ -38,7 +38,6 @@
 
     color: transparent;
     border: none;
-    outline: none;
     background: transparent;
 }
 .slick-prev:hover,
@@ -47,7 +46,6 @@
 .slick-next:focus
 {
     color: transparent;
-    outline: none;
     background: transparent;
 }
 .slick-prev:hover:before,
@@ -162,13 +160,7 @@
 
     color: transparent;
     border: 0;
-    outline: none;
     background: transparent;
-}
-.slick-dots li button:hover,
-.slick-dots li button:focus
-{
-    outline: none;
 }
 .slick-dots li button:hover:before,
 .slick-dots li button:focus:before

--- a/slick/slick-theme.less
+++ b/slick/slick-theme.less
@@ -39,9 +39,7 @@
     transform: translate(0, -50%);
     padding: 0;
     border: none;
-    outline: none;
     &:hover, &:focus {
-        outline: none;
         background: transparent;
         color: transparent;
         &:before {
@@ -131,14 +129,12 @@
             display: block;
             height: 20px;
             width: 20px;
-            outline: none;
             line-height: 0px;
             font-size: 0px;
             color: transparent;
             padding: 5px;
             cursor: pointer;
             &:hover, &:focus {
-                outline: none;
                 &:before {
                     opacity: @slick-opacity-on-hover;
                 }

--- a/slick/slick-theme.scss
+++ b/slick/slick-theme.scss
@@ -77,9 +77,7 @@ $slick-opacity-not-active: 0.25 !default;
     transform: translate(0, -50%);
     padding: 0;
     border: none;
-    outline: none;
     &:hover, &:focus {
-        outline: none;
         background: transparent;
         color: transparent;
         &:before {
@@ -157,14 +155,12 @@ $slick-opacity-not-active: 0.25 !default;
             display: block;
             height: 20px;
             width: 20px;
-            outline: none;
             line-height: 0px;
             font-size: 0px;
             color: transparent;
             padding: 5px;
             cursor: pointer;
             &:hover, &:focus {
-                outline: none;
                 &:before {
                     opacity: $slick-opacity-on-hover;
                 }


### PR DESCRIPTION
This is a way to make this js more accessible as the outline is the most obvious way to tell if user has focused a certain button.