### PR TITLE
fix: Unshown Slides in Infinite Mode

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2557,7 +2557,9 @@
                 animSlide = _.slideCount + targetSlide;
             }
         } else if (targetSlide >= _.slideCount) {
-            if (_.slideCount % _.options.slidesToScroll !== 0) {
+            if (_.options.slidesToScroll == 1) {
+                animSlide = 0;
+            } else if (_.slideCount % _.options.slidesToScroll !== 0) {
                 animSlide = 0;
             } else {
                 animSlide = targetSlide - _.slideCount;


### PR DESCRIPTION
If `slidesToScroll` is set to 1, the modulo expression is always true, so the if-query
jumps into the else branch.
Create an upstream-if-query for this case, so the first slides ist shown correctly after the last one