### PR TITLE
FIx for issue #4065: ".slick-active" class is misplaced when center mode is true and slides total <= slidesToShow

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2329,9 +2329,15 @@
 
         if (_.options.centerMode === true) {
 
-            var evenCoef = _.options.slidesToShow % 2 === 0 ? 1 : 0;
+            var evenCoef;
 
-            centerOffset = Math.floor(_.options.slidesToShow / 2);
+            if (_.options.slidesToShow >= _.$slides.length) {
+                evenCoef = -1;
+                centerOffset = _.options.slidesToShow = _.$slides.length;
+            } else {
+                evenCoef = _.options.slidesToShow % 2 === 0 ? 1 : 0;
+                centerOffset = Math.floor(_.options.slidesToShow / 2);
+            }
 
             if (_.options.infinite === true) {
 


### PR DESCRIPTION
Plunker links to validate:
- [For the Bug](http://plnkr.co/edit/6EHNRvCfwM5JaSvT)
- [For other existing modes](http://plnkr.co/edit/DsW8kUwrynAxvJXa)