### PR TITLE
Don't set slidesToScroll to 1 when using centerMode.

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -529,7 +529,7 @@
             '<div class="slick-list"/>').parent();
         _.$slideTrack.css('opacity', 0);
 
-        if (_.options.centerMode === true || _.options.swipeToSlide === true) {
+        if (_.options.swipeToSlide === true) {
             _.options.slidesToScroll = 1;
         }
 
@@ -1019,7 +1019,7 @@
             .off('focus.slick blur.slick')
             .on(
                 'focus.slick',
-                '*', 
+                '*',
                 function(event) {
                     var $sf = $(this);
 
@@ -1034,7 +1034,7 @@
                 }
             ).on(
                 'blur.slick',
-                '*', 
+                '*',
                 function(event) {
                     var $sf = $(this);
 


### PR DESCRIPTION
I was having issues scrolling two slides using centerMode (with two visible slides). Modifing the if statements allowed other values instead of forcing it to be 1. This works fine for my use cases but I don't know if there's was good reason this was added in the first place.