### PR TITLE
Fix CSP issues by using CSSOM to reset styles when possible

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -889,7 +889,15 @@
                 .removeAttr('aria-hidden')
                 .removeAttr('data-slick-index')
                 .each(function(){
-                    $(this).attr('style', $(this).data('originalStyling'));
+                    var originalStyling = $(this).data('originalStyling');
+                    if (originalStyling) {
+                        $(this).attr('style', originalStyling);
+                    } else {
+                        var style = this.style;
+                        for(var i=style.length-1; i>=0; i--) {
+                            style.removeProperty(style.item(i));
+                        }
+                    }
                 });
 
             _.$slideTrack.children(this.options.slide).detach();


### PR DESCRIPTION
This fix Content-Security-Policy issues for the most common cases (see #2399 and #3799).

That most common case being using slick without having the style attribute set on individual carousel items so that the reset of slick can remove all CSS props using the CSSOM APIs.

I'm not sure if test cases can be added for this.