### PR TITLE
Feature: implement maxHeight for vertical slick

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,39 @@
 </head>
 <body>
 
+<section class="vertical-center-max-height slider">
+  <div>
+    <img src="http://placehold.it/350x100?text=1">
+  </div>
+  <div>
+    <img src="http://placehold.it/350x100?text=2">
+  </div>
+  <div>
+    <img src="http://placehold.it/350x100?text=3">
+  </div>
+  <div>
+    <img src="http://placehold.it/350x100?text=4">
+  </div>
+  <div>
+    <img src="http://placehold.it/350x100?text=5">
+  </div>
+  <div>
+    <img src="http://placehold.it/350x100?text=6">
+  </div>
+  <div>
+    <img src="http://placehold.it/350x100?text=7">
+  </div>
+  <div>
+    <img src="http://placehold.it/350x100?text=8">
+  </div>
+  <div>
+    <img src="http://placehold.it/350x100?text=9">
+  </div>
+  <div>
+    <img src="http://placehold.it/350x100?text=10">
+  </div>
+</section>
+
   <section class="vertical-center-4 slider">
     <div>
       <img src="http://placehold.it/350x100?text=1">
@@ -312,6 +345,15 @@
   <script src="./slick/slick.js" type="text/javascript" charset="utf-8"></script>
   <script type="text/javascript">
     $(document).on('ready', function() {
+        $(".vertical-center-max-height").slick({
+            dots: true,
+            vertical: true,
+            verticalSwiping: true,
+            centerMode: true,
+            slidesToShow: 3,
+            slidesToScroll: 1,
+            maxHeight: 250
+        });
       $(".vertical-center-4").slick({
         dots: true,
         vertical: true,

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -88,7 +88,8 @@
                 vertical: false,
                 verticalSwiping: false,
                 waitForAnimate: true,
-                zIndex: 1000
+                zIndex: 1000,
+                maxHeight: null
             };
 
             _.initials = {
@@ -117,7 +118,8 @@
                 $list: null,
                 touchObject: {},
                 transformsEnabled: false,
-                unslicked: false
+                unslicked: false,
+                listHeightFromSlides: 0,
             };
 
             $.extend(_, _.initials);
@@ -1132,6 +1134,10 @@
             }
         }
 
+        if (_.options.maxHeight !== null && _.listHeightFromSlides > _.options.maxHeight) {
+            verticalOffset = -((verticalHeight * _.options.slidesToShow) + (_.listHeightFromSlides - _.options.maxHeight) / 2);
+        }
+
         if (_.slideCount <= _.options.slidesToShow) {
             _.slideOffset = 0;
             verticalOffset = 0;
@@ -2061,7 +2067,8 @@
                 });
             }
         } else {
-            _.$list.height(_.$slides.first().outerHeight(true) * _.options.slidesToShow);
+            _.listHeightFromSlides = _.$slides.first().outerHeight(true) * _.options.slidesToShow;
+            _.$list.height(_.options.maxHeight !== null && _.listHeightFromSlides > _.options.maxHeight ? _.options.maxHeight : _.listHeightFromSlides);
             if (_.options.centerMode === true) {
                 _.$list.css({
                     padding: (_.options.centerPadding + ' 0px')


### PR DESCRIPTION
Hello,

I propose this PR in order to support **maxHeight** for vertical slick.  
Currently, the list height is determined by number of slides to show and slides height.

For better control, especially in responsive projects (mobile with different screen size), I propose to add an option to set `maxHeight` of slides list.

This option is enabled for `vertical=true` configuration.

If `maxHeight` > *list height computed from slides*, the option is not take in consideration.

Thanks

