### PR TITLE
Update scss url with interpolation

### DIFF
--- a/slick/slick-theme.scss
+++ b/slick/slick-theme.scss
@@ -26,7 +26,7 @@ $slick-opacity-not-active: 0.25 !default;
         @return image-url($url);
     }
     @else {
-        @return url($slick-loader-path + $url);
+        @return url(#{$slick-font-path}#{$url});
     }
 }
 
@@ -35,7 +35,7 @@ $slick-opacity-not-active: 0.25 !default;
         @return font-url($url);
     }
     @else {
-        @return url($slick-font-path + $url);
+        @return url(#{$slick-font-path}#{$url});
     }
 }
 


### PR DESCRIPTION
## introduce

when I use vite, and do something with this file structure


<img width="300" src="https://user-images.githubusercontent.com/1612364/139780144-69c20f58-315d-490c-8a98-2577e16e4286.png"/>


```html
<!-- index.html -->
<script type="module" src="/nested/main.js"></script>
```

```js
// nested/main.js
import './style.scss'
```

```scss
// nested/style.scss
@import "slick-carousel/slick/slick-theme.scss"
```

## issue

vite will replace the url with `@return url(../node_modules/slick-carousel/slick/$slick-loader-path + $url);`

and cause `expected ")".` error
