### PR TITLE
Allow custom character for active dot

### DIFF
--- a/slick/slick-theme.less
+++ b/slick/slick-theme.less
@@ -11,6 +11,7 @@
 @slick-prev-character: "←";
 @slick-next-character: "→";
 @slick-dot-character: "•";
+@slick-active-dot-character: "•";
 @slick-dot-size: 6px;
 @slick-opacity-default: 0.75;
 @slick-opacity-on-hover: 1;
@@ -163,6 +164,10 @@
         &.slick-active button:before {
             color: @slick-dot-color-active;
             opacity: @slick-opacity-default;
+
+            &:before {
+                content: @slick-active-dot-character;
+            }
         }
     }
 }

--- a/slick/slick-theme.scss
+++ b/slick/slick-theme.scss
@@ -16,6 +16,7 @@ $slick-dot-color-active: $slick-dot-color !default;
 $slick-prev-character: "\2190" !default;
 $slick-next-character: "\2192" !default;
 $slick-dot-character: "\2022" !default;
+$slick-active-dot-character: "\2022" !default;
 $slick-dot-size: 6px !default;
 $slick-opacity-default: 0.75 !default;
 $slick-opacity-on-hover: 1 !default;
@@ -189,6 +190,9 @@ $slick-opacity-not-active: 0.25 !default;
         &.slick-active button:before {
             color: $slick-dot-color-active;
             opacity: $slick-opacity-default;
+            &:before {
+                content: $slick-active-dot-character;
+            }
         }
     }
 }


### PR DESCRIPTION
I wanted to use an unfilled circle for inactive dots.

<img width="203" alt="image" src="https://user-images.githubusercontent.com/7904/166312402-6e90c55f-d75d-4024-ac4e-6dc2266ce9b5.png">
