### PR TITLE
FIX: Add font display swap for optimization

### DIFF
--- a/slick/slick-theme.css
+++ b/slick/slick-theme.css
@@ -11,6 +11,7 @@
     font-family: 'slick';
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
 
     src: url('./fonts/slick.eot');
     src: url('./fonts/slick.eot?#iefix') format('embedded-opentype'), url('./fonts/slick.woff') format('woff'), url('./fonts/slick.ttf') format('truetype'), url('./fonts/slick.svg#slick') format('svg');


### PR DESCRIPTION
According to google Lighthouse, you should ensure text remains visible during webfont load (.woff).

More info in [here](https://developer.chrome.com/docs/lighthouse/performance/font-display/?utm_source=lighthouse&utm_medium=devtools).

![image](https://user-images.githubusercontent.com/33470132/224042364-4714e48c-965d-4aa1-bdf4-1d15d765c9d8.png)
