### PR TITLE
fix:  lighthouse ADA issues of slick dot

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1361,19 +1361,14 @@
                 var mappedSlideIndex = tabControlIndexes[i];
 
                 $(this).attr({
-                    'role': 'presentation'
-                });
-
-                $(this).find('button').first().attr({
                     'role': 'tab',
                     'id': 'slick-slide-control' + _.instanceUid + i,
                     'aria-controls': 'slick-slide' + _.instanceUid + mappedSlideIndex,
                     'aria-label': (i + 1) + ' of ' + numDotGroups,
                     'aria-selected': null,
-                    'tabindex': '-1'
+                    'tabindex': '-1'    
                 });
-
-            }).eq(_.currentSlide).find('button').attr({
+            }).eq(_.currentSlide).attr({
                 'aria-selected': 'true',
                 'tabindex': '0'
             }).end();


### PR DESCRIPTION
Because Elements with an ARIA [role] that require children to contain a specific [role] are missing some or all of those required children. so I move the role=tab to upper dom.