### PR TITLE
Apply Update from #1408.

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2365,6 +2365,26 @@
 
                 }
 
+            } else {
+                 _.$slides
+                     .slice(index - centerOffset + evenCoef, index + centerOffset + 1)
+                     .addClass('slick-active')
+                     .attr('aria-hidden', 'false');
+
+
+                if (index === 0) {
+
+                    allSlides
+                        .eq( _.options.slidesToShow + _.slideCount + 1 )
+                        .addClass('slick-center');
+
+                } else if (index === _.slideCount - 1) {
+
+                    allSlides
+                        .eq(_.options.slidesToShow)
+                        .addClass('slick-center');
+
+                }
             }
 
             _.$slides


### PR DESCRIPTION
This PR duplicates the logic that sets the active slide for the center mode when infinite is turned off. Otherwise all slides end up with `aria-hidden=true` and are ignored by screen readers. This update should resolve the issues by setting `aria-hidden=false` as expected with out making the slides loop the way infinite does.

See #1408.