### PR TITLE
Update slick.css

### DIFF
--- a/slick/slick.css
+++ b/slick/slick.css
@@ -35,7 +35,7 @@
 .slick-list.dragging
 {
     cursor: pointer;
-    cursor: hand;
+    cursor: grab;
 }
 
 .slick-slider .slick-track,


### PR DESCRIPTION
The CSS cursor property does not have a hand value. Instead, it has been updated to the grab value.