### PR TITLE
Fix compatibility with Dart Sass 3.0.0

### DIFF
--- a/slick/slick-theme.scss
+++ b/slick/slick-theme.scss
@@ -1,4 +1,5 @@
 @charset "UTF-8";
+@use "sass:meta";
 
 // Default Variables
 
@@ -22,7 +23,7 @@ $slick-opacity-on-hover: 1 !default;
 $slick-opacity-not-active: 0.25 !default;
 
 @function slick-image-url($url) {
-    @if function-exists(image-url) {
+    @if meta.function-exists(image-url) {
         @return image-url($url);
     }
     @else {
@@ -31,7 +32,7 @@ $slick-opacity-not-active: 0.25 !default;
 }
 
 @function slick-font-url($url) {
-    @if function-exists(font-url) {
+    @if meta.function-exists(font-url) {
         @return font-url($url);
     }
     @else {


### PR DESCRIPTION
```
Deprecation Warning [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use meta.function-exists instead.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
35 │     @if function-exists(font-url) {
```