### PR TITLE
fix: umd

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -19,8 +19,19 @@
     'use strict';
     if (typeof define === 'function' && define.amd) {
         define(['jquery'], factory);
-    } else if (typeof exports !== 'undefined') {
-        module.exports = factory(require('jquery'));
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = function( root, jQuery ) {
+            if ( jQuery === undefined ) {
+                if ( typeof window !== 'undefined' ) {
+                    jQuery = require('jquery');
+                }
+                else {
+                    jQuery = require('jquery')(root);
+                }
+            }
+            factory(jQuery);
+            return jQuery;
+        };
     } else {
         factory(jQuery);
     }


### PR DESCRIPTION
The template for `Universal Module Definition` for jQuery plugins could be found [here](https://github.com/umdjs/umd/blob/master/templates/jqueryPlugin.js).

I applied this template to `slick.js`, because I running problems using rollup, which inject the `exports` variable, leading slick to think it is in a commanJS environment. It should check `module.exports` as well.

Example rollup build output, that lead to the error: `ReferenceError: require is not defined`

```js
var __getOwnPropNames = Object.getOwnPropertyNames;
var __commonJS = (cb, mod) => function __require() {
  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
};
var require_slick_002 = __commonJS({
  "assets/slick-sGyIvxO8.js"(exports, module) {
    // ... jquery and slick
  }
});
export default require_slick_002();
```
