### PR TITLE
Using unitless 0 instead 0px values

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -295,12 +295,10 @@
                     step: function(now) {
                         now = Math.ceil(now);
                         if (_.options.vertical === false) {
-                            animProps[_.animType] = 'translate(' +
-                                now + 'px, 0)';
+                            animProps[_.animType] = 'translate(' + now + 'px, 0)';
                             _.$slideTrack.css(animProps);
                         } else {
-                            animProps[_.animType] = 'translate(0,' +
-                                now + 'px)';
+                            animProps[_.animType] = 'translate(0, ' + now + 'px)';
                             _.$slideTrack.css(animProps);
                         }
                     },
@@ -319,7 +317,7 @@
                 if (_.options.vertical === false) {
                     animProps[_.animType] = 'translate3d(' + targetLeft + 'px, 0, 0)';
                 } else {
-                    animProps[_.animType] = 'translate3d(0,' + targetLeft + 'px, 0)';
+                    animProps[_.animType] = 'translate3d(0, ' + targetLeft + 'px, 0)';
                 }
                 _.$slideTrack.css(animProps);
 

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -296,10 +296,10 @@
                         now = Math.ceil(now);
                         if (_.options.vertical === false) {
                             animProps[_.animType] = 'translate(' +
-                                now + 'px, 0px)';
+                                now + 'px, 0)';
                             _.$slideTrack.css(animProps);
                         } else {
-                            animProps[_.animType] = 'translate(0px,' +
+                            animProps[_.animType] = 'translate(0,' +
                                 now + 'px)';
                             _.$slideTrack.css(animProps);
                         }
@@ -317,9 +317,9 @@
                 targetLeft = Math.ceil(targetLeft);
 
                 if (_.options.vertical === false) {
-                    animProps[_.animType] = 'translate3d(' + targetLeft + 'px, 0px, 0px)';
+                    animProps[_.animType] = 'translate3d(' + targetLeft + 'px, 0, 0)';
                 } else {
-                    animProps[_.animType] = 'translate3d(0px,' + targetLeft + 'px, 0px)';
+                    animProps[_.animType] = 'translate3d(0,' + targetLeft + 'px, 0)';
                 }
                 _.$slideTrack.css(animProps);
 
@@ -2034,8 +2034,8 @@
         if (_.options.rtl === true) {
             position = -position;
         }
-        x = _.positionProp == 'left' ? Math.ceil(position) + 'px' : '0px';
-        y = _.positionProp == 'top' ? Math.ceil(position) + 'px' : '0px';
+        x = _.positionProp == 'left' ? Math.ceil(position) + 'px' : '0';
+        y = _.positionProp == 'top' ? Math.ceil(position) + 'px' : '0';
 
         positionProps[_.positionProp] = position;
 
@@ -2047,7 +2047,7 @@
                 positionProps[_.animType] = 'translate(' + x + ', ' + y + ')';
                 _.$slideTrack.css(positionProps);
             } else {
-                positionProps[_.animType] = 'translate3d(' + x + ', ' + y + ', 0px)';
+                positionProps[_.animType] = 'translate3d(' + x + ', ' + y + ', 0)';
                 _.$slideTrack.css(positionProps);
             }
         }


### PR DESCRIPTION
In CSS, transform: translate3d(0px, 0px, 0px) and transform: translate3d(0, 0, 0) are functionally identical, as browsers interpret a unitless 0 as 0px in this context.

Can we use unitless 0 against 0px in translate3d(0, 0, 0) and translate() as a more modern and generally preferred approach because it is cleaner and shorter? Well, 0px and 0em are still 0.