### PR TITLE
Update jsDelivr links to use 'master' version

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,20 +17,20 @@ to serve the files as close, and fast as possible to your users:
 - https://cdnjs.com/libraries/slick-carousel
 - [https://cdn.jsdelivr.net/gh/kenwheeler/slick/](https://cdn.jsdelivr.net/gh/kenwheeler/slick/)
 
-##### Example using jsDelivr
+##### Example using (master) from jsDelivr
 
 Just add a link to the css file in your `<head>`:
 
 ```html
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/kenwheeler/slick@1.8.1/slick/slick.css"/>
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/kenwheeler/slick@master/slick/slick.css"/>
 <!-- Add the slick-theme.css if you want default styling -->
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/kenwheeler/slick@1.8.1/slick/slick-theme.css"/>
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/kenwheeler/slick@master/slick/slick-theme.css"/>
 ```
 
 Then, before your closing ```<body>``` tag add:
 
 ```html
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/kenwheeler/slick@1.8.1/slick/slick.min.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/kenwheeler/slick@master/slick/slick.min.js"></script>
 ```
 
 #### Package Managers

--- a/README.markdown
+++ b/README.markdown
@@ -17,9 +17,9 @@ to serve the files as close, and fast as possible to your users:
 - https://cdnjs.com/libraries/slick-carousel
 - [https://cdn.jsdelivr.net/gh/kenwheeler/slick/](https://cdn.jsdelivr.net/gh/kenwheeler/slick/)
 
-##### Example using (master) from jsDelivr
+##### Example using from jsDelivr
 
-Just add a link to the css file in your `<head>`:
+Just add a link to the css file in your `<head>`. If you are using jQuery 4.0 or higher, use the following:
 
 ```html
 <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/kenwheeler/slick@master/slick/slick.css"/>
@@ -33,6 +33,20 @@ Then, before your closing ```<body>``` tag add:
 <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/kenwheeler/slick@master/slick/slick.min.js"></script>
 ```
 
+If you are using jQuery 3.0 or lower, use the following:
+
+```html
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/kenwheeler/slick@1.8.1/slick/slick.css"/>
+<!-- Add the slick-theme.css if you want default styling -->
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/kenwheeler/slick@1.8.1/slick/slick-theme.css"/>
+```
+
+Then, before your closing ```<body>``` tag add:
+
+```html
+<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/kenwheeler/slick@1.8.1/slick/slick.min.js"></script>
+```
+
 #### Package Managers
 
 ```sh
@@ -42,6 +56,9 @@ bower install --save slick-carousel
 # NPM
 npm install slick-carousel
 ```
+
+> [!NOTE]
+> Version 2.0.0 of Slick is currently not available via Bower or NPM. Please use the CDN links above to get the latest version.
 
 #### Contributing
 


### PR DESCRIPTION
Change example links to pull the "latest" from github instead of the old tag