### PR TITLE
Clean up transform property in slick.scss

### DIFF
--- a/slick/slick.scss
+++ b/slick/slick.scss
@@ -34,10 +34,6 @@
 }
 .slick-slider .slick-track,
 .slick-slider .slick-list {
-    -webkit-transform: translate3d(0, 0, 0);
-    -moz-transform: translate3d(0, 0, 0);
-    -ms-transform: translate3d(0, 0, 0);
-    -o-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0);
 }
 


### PR DESCRIPTION
Removed vendor prefixes for transform property in slick.scss.